### PR TITLE
fix(core): unlink stale subs in _mark processing branch

### DIFF
--- a/packages/core/src/core/atom.test.ts
+++ b/packages/core/src/core/atom.test.ts
@@ -1,6 +1,7 @@
 import { expect, subscribe, test, vi } from 'test'
 
 import { withComputed } from '../extensions'
+import { reset } from '../methods'
 import {
   _read,
   type Atom,
@@ -396,4 +397,42 @@ test('middlewares order', () => {
 
   expect(a()).toBe(0)
   expect(logs).toEqual([2, 1])
+})
+
+test('_mark on processing sub does not duplicate subs entries', () => {
+  // Reproduces the doubling of `subs` that happens when `_mark` finds a
+  // subscriber in `processing=true`. In real code this happens via
+  // `withAsync`'s `asyncMiddleware` -> `retryComputed(pending)` ->
+  // `reset(pending)` -> `_mark(pending)` while a subscriber that reads both
+  // `pending` and other derived atoms of the same chain is mid-compute.
+  //
+  // We model the same shape with primitives: a subscriber reads `a` and
+  // `b`, and `b`'s middleware calls `reset(a)` after computing — so during
+  // the subscriber's compute, a `_mark(a)` runs and finds the subscriber
+  // currently processing.
+  const name = 'markProcessing'
+  const root = atom(0, `${name}.root`)
+  const a = computed(() => root() + 1, `${name}.a`)
+  const b = computed(() => root() + 100, `${name}.b`).extend(
+    withMiddleware(() => (next, ...args) => {
+      const result = next(...args)
+      reset(a)
+      return result
+    }),
+  )
+
+  const subscriber = computed(() => a() + b(), `${name}.subscriber`)
+
+  subscriber.subscribe()
+
+  // Baseline.
+  expect(_read(a)!.subs.length).toBe(1)
+  expect(_read(b)!.subs.length).toBe(1)
+
+  for (let i = 1; i <= 5; i++) {
+    root.set(i)
+    notify()
+    expect(_read(a)!.subs.length, `a.subs after set #${i}`).toBe(1)
+    expect(_read(b)!.subs.length, `b.subs after set #${i}`).toBe(1)
+  }
 })

--- a/packages/core/src/core/atom.ts
+++ b/packages/core/src/core/atom.ts
@@ -395,7 +395,11 @@ export let _mark = (frame: Frame) => {
     let sub = frame.subs[i]!
     if (sub.__reatom.processing) {
       _enqueue(() => {
-        _copy(frame.root.store.get(sub)!).pubs.splice(1)
+        let curFrame = frame.root.store.get(sub)!
+        let oldPubs = curFrame.pubs
+        _copy(curFrame).pubs.splice(1)
+        // unlink stale subs entries so a future relink doesn't duplicate them
+        unlink(sub, oldPubs)
       }, 'compute')
     }
 


### PR DESCRIPTION
## Кратко

Исправляет экспоненциальный рост `Frame.subs` (и зависание вкладки)
в сценарии, когда один подписчик читает несколько производных атомов одной
async-цепочки, а корневой примитивный атом обновляется повторно.

## Воспроизведение

Один подписчик читает три производных атома одной цепочки:

```ts
const selectedCurrency = atom<{ id: number } | null>(null)

const currenciesAsync = computed(
  () => wrap(fetchCurrencies()),
).extend(withAsyncData({ initState: [] }))

const depositSelected = computed(() => {
  const list = currenciesAsync.data()
  const sel = selectedCurrency()
  return list.find(c => c.id === sel?.id) ?? list[0] ?? null
})

const availableAsync = computed(() => {
  const c = depositSelected()
  if (!c) return Promise.resolve(null)
  return wrap(getAddress(c))
}).extend(withAsyncData({ initState: null }))

// Один подписчик читает три производных атома цепочки:
const _render = computed(() => [
  depositSelected(),
  availableAsync.data(),
  availableAsync.pending(),
])
_render.subscribe(() => {})
```

Каждый `selectedCurrency.set(...)` удваивает количество записей в
`availableAsync.data.subs`, `availableAsync.pending.subs` и
`depositSelected.subs`:

| клик | data.subs | pending.subs | depositSelected.subs | время `set()` |
|-----:|----------:|-------------:|---------------------:|--------------:|
|   1  |     1     |      1       |          5           | 0.0 ms |
|   2  |     2     |      2       |          6           | 0.0 ms |
|   3  |     4     |      4       |          8           | 0.1 ms |
|   4  |     8     |      8       |         12           | 0.1 ms |
|   5  |    16     |     16       |         20           | 0.0 ms |
|   6  |    32     |     32       |         36           | 0.5 ms |
|   7  |    64     |     64       |         68           | 3.6 ms |
|   8  |   128     |    128       |        132           | 192 ms (вкладка вскоре зависает) |

В каждый \`subs\` пушится один и тот же атом (`_render`) много раз.

react - https://stackblitz.com/edit/vitejs-vite-uzfqzec5?file=src%2Fmain.tsx
ts - https://stackblitz.com/edit/vitejs-vite-zfbtjfrq?file=src%2Fmain.ts

## Корневая причина

`asyncMiddleware` (в `withAsync`) на каждом вычислении async-таргета
вызывает `retryComputed(pending)` → `reset(pending)` → `_mark(pendingFrame)`
в момент, когда подписчик находится в середине собственного вычисления.
Полная цепочка: `_render → data() → target() → asyncMiddleware →
retryComputed`.

Когда `_mark` (`packages/core/src/core/atom.ts`) обходит `pending.subs` и
встречает `_render` с `__reatom.processing === true`, он ставит в очередь:

\`\`\`js
_enqueue(() => {
  _copy(frame.root.store.get(sub)!).pubs.splice(1)
}, 'compute')
\`\`\`

Это обрезает `_render.frame.pubs` до `[null]` — но **не отвязывает**
`_render` из `subs` его старых pubs. Позже, когда `_render` пересчитывается,
`atomMiddleware` захватывает `pubs = [null]` (локальная переменная
`let { state, pubs } = frame`), выполняет тело, заново собирая pubs, и
вызывает `relink(frame, [null])`.

Так как `oldPubs.length === 1`, цикл `unlink`
(`for (i = oldPubs.length - 1; i > 0; i--)`) делает ноль итераций, а `link()`
добавляет `_render` в `subs` каждого нового pub. Старые записи остаются →
дубликаты.

На следующий клик `_mark` обходит уже более длинные `subs`, ставит больше
reset-лямбд, каждая порождает новые дубликаты → удвоение на цикл.

## Фикс

Снимаем снимок текущих pubs до splice и вызываем `unlink`, чтобы сохранить
согласованность двунаправленного учёта `pubs ↔ subs`:

\`\`\`diff
 if (sub.__reatom.processing) {
   _enqueue(() => {
-    _copy(frame.root.store.get(sub)!).pubs.splice(1)
+    let curFrame = frame.root.store.get(sub)!
+    let oldPubs = curFrame.pubs
+    _copy(curFrame).pubs.splice(1)
+    // unlink stale subs entries so a future relink doesn't duplicate them
+    unlink(sub, oldPubs)
   }, 'compute')
 }
\`\`\`

`unlink` корректно обрабатывает легитимные дубликаты от нескольких чтений
(одно удаление на каждое вхождение в `oldPubs`), поэтому существующая
семантика `core/diamonds.test.ts`
(`subs).toEqual([a2, a2, a2, a3])` для зависимости, читаемой 3 раза)
сохраняется — мы НЕ дедуплицируем в `link`.

## Test plan

- [x] Регресс-тест в `packages/core/src/core/atom.test.ts`
  (`_mark on processing sub does not duplicate subs entries`) воспроизводит
  удвоение на чистых примитивах + `withMiddleware` + `reset` (без зависимости
  от async). Без фикса падает на первом `set()` (`subs.length === 2`),
  с фиксом проходит (`subs.length === 1`).
- [x] Полный сьют `@reatom/core`: 332 passed, 5 skipped, 0 failures.
- [x] Проверено руками в реальном приложении — `set()` больше не растёт по
  времени при повторных обновлениях родителя.
