### PR TITLE
Add v1001 notice to docs pages

### DIFF
--- a/docs/src/components/starlight/PageTitle.astro
+++ b/docs/src/components/starlight/PageTitle.astro
@@ -5,3 +5,41 @@ import Default from '@astrojs/starlight/components/PageTitle.astro'
 <Default>
   <slot />
 </Default>
+
+<aside class="version-alert" aria-label="New Reatom docs version">
+  <span class="version-alert__badge">v1001</span>
+  <span>
+    New docs are available. It is better to check
+    <a href="https://v1001.reatom.dev">v1001.reatom.dev</a>.
+  </span>
+</aside>
+
+<style>
+  .version-alert {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 1rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--sl-color-accent-low);
+    border-radius: 0.75rem;
+    color: var(--sl-color-white);
+    background: linear-gradient(135deg, var(--sl-color-accent-low), transparent);
+    font-size: var(--sl-text-sm);
+  }
+
+  .version-alert__badge {
+    flex-shrink: 0;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    color: var(--sl-color-black);
+    background-color: var(--sl-color-text-accent);
+    font-weight: 700;
+    letter-spacing: 0.02em;
+  }
+
+  .version-alert a {
+    color: var(--sl-color-text-accent);
+    font-weight: 700;
+  }
+</style>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add a compact v1001 notice below Starlight page titles so docs readers are pointed to `https://v1001.reatom.dev`.

### Testing
- `pnpm --dir docs exec astro dev --host 0.0.0.0 --port 4321`
- `curl --fail --silent http://localhost:4321/start/ | rg "v1001\\.reatom\\.dev|v3\\.reatom\\.dev|version-alert"`
- `pnpm --dir docs exec astro build`
- Manual browser walkthrough confirmed the alert appears on `/start/` and `/handbook/history/`.

<a href="https://cursor.com/agents/bc-ef4f0414-be57-4d9b-a9fe-6cfaa76c26ce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fv1001_docs_alert_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-23f3a01b-3ada-472b-97f3-c67d872e75ae" alt="v1001_docs_alert_walkthrough.mp4" /></a>
![Introduction page v1001 alert](https://cursor.com/artifacts/c/art-a30a525f-63d4-4a51-96f0-e6ac267dadf2)
![History page v1001 alert](https://cursor.com/artifacts/c/art-9ab4b5f2-12d8-4d1e-9a4b-54bef1ccdec0)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef4f0414-be57-4d9b-a9fe-6cfaa76c26ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef4f0414-be57-4d9b-a9fe-6cfaa76c26ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

