### PR TITLE
fix(core): sync atom from URL on back navigation when false param is omitted

### DIFF
--- a/packages/core/src/routing/searchParams.test.browser.ts
+++ b/packages/core/src/routing/searchParams.test.browser.ts
@@ -2,6 +2,7 @@ import { beforeEach, expect, test, vi } from 'test'
 
 import { atom } from '../core/atom'
 import { wrap } from '../methods'
+import { reatomBoolean } from '../primitives/reatomBoolean'
 import { sleep } from '../utils'
 import { urlAtom } from '../web/url'
 import { searchParamsAtom, withSearchParams } from './searchParams'
@@ -164,6 +165,38 @@ test('search reset', async () => {
 
   expect(urlAtom().search).toBe('')
   expect(urlAtom().pathname).toBe('/results')
+})
+
+test('back navigation with omitted false search param', async () => {
+  history.replaceState({}, '', '/')
+
+  const open = reatomBoolean(false, 'open').extend(
+    withSearchParams('open', {
+      parse: (raw) => (raw ? Boolean(Number(raw)) : false),
+      serialize: (state) => (state ? '1' : undefined),
+    }),
+  )
+
+  open.subscribe()
+
+  await wrap(sleep())
+
+  expect(open()).toBe(false)
+  expect(urlAtom().search).toBe('')
+
+  open.setTrue()
+
+  await wrap(sleep())
+
+  expect(open()).toBe(true)
+  expect(urlAtom().search).toBe('?open=1')
+
+  history.back()
+
+  await wrap(sleep())
+
+  expect(open()).toBe(false)
+  expect(urlAtom().search).toBe('')
 })
 
 test('inactive subpath should not affect mutated atoms', async () => {

--- a/packages/core/src/routing/searchParams.ts
+++ b/packages/core/src/routing/searchParams.ts
@@ -218,6 +218,11 @@ export function withSearchParams<T = string>(
                 return
               }
 
+              if (key in prev && currentPath === prevUrl.pathname) {
+                state = parse(undefined) as AtomState<Target>
+                return
+              }
+
               const prevState = serialize(state)
               if (prevState !== undefined) {
                 _enqueue(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When using `withSearchParams` with `serialize: (state) => (state ? '1' : undefined)`, native browser back navigation from `?open=1` to a URL without the param did not update the atom to `false`. The URL briefly lost `open=1` and then it was re-added, causing a visible flicker.

Using `serialize: (state) => (state ? '1' : '0')` worked around the issue but left unwanted `open=0` in the URL.

## Root cause

In `withComputed`, when a search param disappeared from the URL, the extension tried to restore it from the current atom state if `serialize(state)` was defined. After back navigation the atom was still `true`, so `serialize(true)` returned `'1'` and the param was pushed back into the URL.

## Fix

When the param was present in the previous URL snapshot but missing in the next one **on the same pathname**, treat the URL as the source of truth and update the atom via `parse(undefined)` instead of re-syncing the stale atom value back to the URL.

Param re-sync on pathname change within an active path scope (e.g. wildcard routes) is preserved.

## Test

Added `back navigation with omitted false search param` browser test that reproduces the bug with `reatomBoolean` + `withSearchParams` and verifies atom/URL state after `history.back()`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b9408bc-76de-4ba5-985d-bd15ce1ea71a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b9408bc-76de-4ba5-985d-bd15ce1ea71a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

