### PR TITLE
docs: fix small grammar bits in routing guide and Vue README

### DIFF
--- a/docs/src/content/docs/start/routing.md
+++ b/docs/src/content/docs/start/routing.md
@@ -24,7 +24,7 @@ When the user navigates to `/login`, `loginRoute()` will return an empty object 
 
 ## Route Loaders for State Management
 
-A powerful feature is the `loader` option in a route definition. This function executes when the route becomes active and can be used to load data, it uses async data extension, which we was introduced in the [Extensions guide](/start/extensions). The more more cool feature is that you can create state that should only exist while the route is active. We call it a "computed factory" pattern.
+A powerful feature is the `loader` option in a route definition. This function executes when the route becomes active and can be used to load data, it uses the async data extension introduced in the [Extensions guide](/start/extensions). An even cooler feature is that you can create state that should only exist while the route is active. We call it a "computed factory" pattern.
 
 This is perfect for managing forms, for example. By creating a form inside a route's loader, you ensure it's fresh every time the user visits the route and is automatically cleaned up when they navigate away, preventing issues like old data appearing after logout. But still, the state is global, so you can access them from any component.
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -2,7 +2,7 @@ Reatom integration for Vue Composition API.
 
 Vue has simple and powerful enough primitives for state processing out of the box, refs can be created outside the component and most of the tasks are solved by it. But there are a number of issues that reatom covers better.
 
-- Atoms has lifecycle hooks, usefull for states used in many components. It allows you to init a resource on the first subscription and dispose the resource on the last unsubscription.
+- Atoms have lifecycle hooks, useful for states used in many components. They let you initialize a resource on the first subscription and dispose of it on the last unsubscription.
 - Actions help you group and better log and debug your logic. Reatom allows you to trace the entire chain of data transformations through all sync and async actions and atoms.
 - Reatom is a perfect solution as a multi frontend core as it is small, powerful and already has adapters for vue, react, solid, svelte (lit and angular adapters in development).
 - Reatom has very powerful primitives for describing asynchronous logic, gathering the best of rxjs, redux-saga and TanStack Query. There seem to be no alternatives here.


### PR DESCRIPTION
Two small grammar fixes spotted while reading through the docs:

- `docs/src/content/docs/start/routing.md`: dropped an extra subject ("which we was introduced" → "introduced") and a doubled word ("more more cool feature" → "an even cooler feature") in the Route Loaders paragraph.
- `packages/vue/README.md`: "Atoms has" → "Atoms have" (plural), "usefull" → "useful" in the lifecycle-hooks bullet.

Same paragraph reads cleaner without changing meaning.