### PR TITLE
fix(core): rehydrate all IndexedDB atoms from cold start

### DIFF
--- a/packages/core/src/persist/web-storage/indexedDb.test.browser.ts
+++ b/packages/core/src/persist/web-storage/indexedDb.test.browser.ts
@@ -1,8 +1,9 @@
-import { expect, test } from 'test'
+import { beforeEach, describe, expect, test } from 'test'
 
 import { atom } from '../../core'
 import { wrap } from '../../methods'
 import { sleep } from '../../utils'
+import type { PersistRecord } from '../index'
 import { reatomPersistIndexedDb, withIndexedDb } from './indexedDb'
 
 // Completely suppress console.warn to avoid spam during IndexedDB tests
@@ -187,4 +188,103 @@ test('IndexedDB adapter initialization', async () => {
 
   channel1.close()
   channel2.close()
+})
+
+describe('cold-start rehydration with multiple atoms', () => {
+  const seedRecord = async <T,>(key: string, data: T) => {
+    const idb = await import('idb-keyval')
+    const store = idb.createStore('reatom_default', 'atoms')
+    const rec: PersistRecord<T> = {
+      data,
+      id: 0,
+      timestamp: Date.now(),
+      to: Date.now() + 1_000_000,
+      version: 0,
+    }
+    await idb.set(key, rec, store)
+  }
+
+  const clearRecord = async (key: string) => {
+    const idb = await import('idb-keyval')
+    const store = idb.createStore('reatom_default', 'atoms')
+    await idb.del(key, store)
+  }
+
+  // Reset the lazy `idb-keyval` import so each test exercises the cold-start path.
+  beforeEach(() => {
+    const rt = (globalThis as any).__REATOM as { persistIndexedDbLazy?: any }
+    if (rt?.persistIndexedDbLazy) {
+      rt.persistIndexedDbLazy.promise = null
+      rt.persistIndexedDbLazy.module = null
+    }
+  })
+
+  test('rehydrates BOTH atoms from a cold start', async () => {
+    const keyA = 'regression.cold.a'
+    const keyB = 'regression.cold.b'
+
+    await wrap(seedRecord(keyA, 'A-COLD'))
+    await wrap(seedRecord(keyB, 'B-COLD'))
+
+    try {
+      const a = atom<string | null>(null, 'regressionColdA').extend(
+        withIndexedDb(keyA),
+      )
+      const b = atom<string | null>(null, 'regressionColdB').extend(
+        withIndexedDb(keyB),
+      )
+
+      const unsubA = a.subscribe(() => {})
+      const unsubB = b.subscribe(() => {})
+
+      await wrap(sleep(200))
+
+      expect(a()).toBe('A-COLD')
+      expect(b()).toBe('B-COLD')
+
+      unsubA()
+      unsubB()
+    } finally {
+      await wrap(clearRecord(keyA))
+      await wrap(clearRecord(keyB))
+    }
+  })
+
+  test('rehydrates BOTH atoms after disconnect-reconnect cycle', async () => {
+    // Mimics React StrictMode / quick effect re-runs during the rehydrate window.
+    const keyA = 'regression.churn.a'
+    const keyB = 'regression.churn.b'
+
+    await wrap(seedRecord(keyA, 'A-CHURN'))
+    await wrap(seedRecord(keyB, 'B-CHURN'))
+
+    try {
+      const a = atom<string | null>(null, 'regressionChurnA').extend(
+        withIndexedDb(keyA),
+      )
+      const b = atom<string | null>(null, 'regressionChurnB').extend(
+        withIndexedDb(keyB),
+      )
+
+      const unsubA1 = a.subscribe(() => {})
+      const unsubB1 = b.subscribe(() => {})
+
+      // Drop & resubscribe before the IDB IIFEs resolve.
+      unsubA1()
+      unsubB1()
+      const unsubA2 = a.subscribe(() => {})
+      const unsubB2 = b.subscribe(() => {})
+
+      await wrap(sleep(200))
+
+      expect(a()).toBe('A-CHURN')
+      expect(b()).toBe('B-CHURN')
+
+      unsubA2()
+      unsubB2()
+    } finally {
+      await wrap(clearRecord(keyA))
+      await wrap(clearRecord(keyB))
+    }
+  })
 })

--- a/packages/core/src/persist/web-storage/indexedDb.ts
+++ b/packages/core/src/persist/web-storage/indexedDb.ts
@@ -39,30 +39,32 @@ export type BroadcastMessage =
       key: string
     }
 
-// One-time check for optional idb-keyval dependency
+// Lazy `idb-keyval` import. Memoizes the in-flight promise so concurrent
+// callers share one resolution instead of racing on a checked-but-not-loaded
+// state.
 let idbLazy = _createGlobal(
   'persistIndexedDbLazy',
   (): {
-    checked: boolean
+    promise: Promise<any> | null
     module: any
   } => ({
-    checked: false,
+    promise: null,
     module: null,
   }),
 )
 
-const checkIdb = async () => {
-  if (idbLazy.checked) return idbLazy.module
-  idbLazy.checked = true
+const checkIdb = (): Promise<any> => {
+  if (idbLazy.promise) return idbLazy.promise
 
-  try {
-    idbLazy.module = await import('idb-keyval')
-  } catch {
-    console.warn('idb-keyval not available - using memory storage fallback')
-    idbLazy.module = null
-  }
+  idbLazy.promise = import('idb-keyval').then(
+    (module) => (idbLazy.module = module),
+    () => {
+      console.warn('idb-keyval not available - using memory storage fallback')
+      return (idbLazy.module = null)
+    },
+  )
 
-  return idbLazy.module
+  return idbLazy.promise
 }
 
 /**


### PR DESCRIPTION
## Summary

`checkIdb()` in `packages/core/src/persist/web-storage/indexedDb.ts` flipped `idbLazy.checked = true` **synchronously** before awaiting `import('idb-keyval')`. Any second async caller that arrived in the same tick saw `checked: true && module: null` and returned `null` immediately. The downstream `if (idbLib && store)` gate then silently fell through to the memory-storage branch.

In practice this meant that when **several atoms call `withIndexedDb` in the same tick at page load** — the common React mount-time pattern — only the first atom's subscribe-IIFE actually got the `idb-keyval` module. Every other atom silently never read IndexedDB at all, so they stayed at their initial state even though their records were sitting in the store.

## Fix

Cache the **in-flight import promise** (not just its resolved value) and have every caller `await` the shared promise.

No public API change, no new dependencies, BroadcastChannel cross-tab sync untouched.

## Repro & tests

Added a `describe('cold-start rehydration with multiple atoms', ...)` block in `indexedDb.test.browser.ts` with two tests:

1. **Both atoms rehydrate from a cold start** — pre-seed two records, create two atoms with `withIndexedDb(key)`, subscribe both in the same tick, await, assert both rehydrated.
2. **Both atoms rehydrate after a disconnect-reconnect cycle** — same setup plus the React StrictMode-style subscribe churn that surfaced this in real apps.

Both tests fail against `v1001` HEAD before the fix and pass with it.

## Verification

- New tests: `pass` (both green)
- Full browser persist suite: `96/96 passed`
- Persist node tests: `5/5 passed`
- Pre-existing unrelated failures (`withAsyncData`, `withChangeHook`, etc.) verified pre-existing via stash-comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)