### PR TITLE
fix(async): do not call onReject for abort rejections

### DIFF
--- a/packages/core/src/async/withAsync.test.ts
+++ b/packages/core/src/async/withAsync.test.ts
@@ -3,7 +3,7 @@ import { expect, test, vi } from 'test'
 import { _read, action, atom, computed } from '../core'
 import { withCallHook } from '../extensions'
 import { retryComputed, wrap } from '../methods'
-import { noop, sleep } from '../utils'
+import { noop, sleep, throwAbort } from '../utils'
 import { withAsync } from './withAsync'
 
 test('action', async () => {
@@ -85,6 +85,32 @@ test('action error handling', async () => {
     payload: 'Success',
     params: [false],
   })
+})
+
+test('abort rejection settles without calling onReject', async () => {
+  const fetch = action(async (shouldAbort: boolean) => {
+    await wrap(sleep())
+    if (shouldAbort) throwAbort('aborted')
+    return 'Success'
+  }, 'abortAsync.data').extend(withAsync())
+
+  const onReject = vi.fn()
+  fetch.onReject.extend(withCallHook((call) => onReject(call)))
+  const onSettle = vi.fn()
+  fetch.onSettle.extend(withCallHook((call) => onSettle(call)))
+
+  await wrap(fetch(true).catch(noop))
+
+  // the abort settles the async lifecycle but is not a business rejection
+  expect(onReject).not.toHaveBeenCalled()
+  expect(onSettle).toHaveBeenCalledTimes(1)
+  expect(fetch.error()).toBeUndefined()
+  expect(fetch.pending()).toBe(0)
+
+  // a real rejection still reaches onReject
+  await wrap(fetch(false))
+  expect(onReject).not.toHaveBeenCalled()
+  expect(onSettle).toHaveBeenCalledTimes(2)
 })
 
 test('computed retry', async () => {

--- a/packages/core/src/async/withAsync.ts
+++ b/packages/core/src/async/withAsync.ts
@@ -357,7 +357,11 @@ export let withAsync: {
           }, frame),
           bind((error) => {
             if (cacheState) pending.set((state) => state + 1)
-            abortVar.spawn(onReject, error, params)
+            if (isAbort(error)) {
+              abortVar.spawn(onSettle, { error, params })
+            } else {
+              abortVar.spawn(onReject, error, params)
+            }
           }, frame),
         )
       }


### PR DESCRIPTION
## Problem

`onReject` is called with an `AbortError`. Aborts should not surface as business rejections on the public `onReject` lifecycle action (#1289).

The most common trigger is routing: a route loader aborts with `'unmatch'` when its route stops matching (correct teardown), but that abort was dispatched to `onReject`. Subscribers handling `onReject` as a real error saw spurious `AbortError`s, and `connectLogger` printed them as rejections on every navigation.

## Cause

In `withAsync`, the promise rejection branch always spawned `onReject`. `onReject` already skipped `error.set` for aborts (via `isAbort`), but the action itself still fired — so it reached `onReject` subscribers and the logger.

## Fix

Route abort rejections straight to `onSettle` instead of `onReject`:

```ts
bind((error) => {
  if (cacheState) pending.set((state) => state + 1)
  if (isAbort(error)) {
    abortVar.spawn(onSettle, { error, params })
  } else {
    abortVar.spawn(onReject, error, params)
  }
}, frame),
```

The async lifecycle still settles — `pending` is decremented, `onSettle` is called with the abort — so loader teardown and `pending`/`ready` accounting are unchanged. Only the misclassification of an abort as a rejection is removed.

## Why not skip non-matching loader evaluation instead

An earlier approach (guarding the `urlAtom` loader loops with `if (routeAtom())`) looked appealing but breaks `route loader lazyness (abortable)`: that contract relies on re-evaluating an unsubscribed loader on navigation so it can abort and tear down its prior run. Skipping that evaluation drops the teardown. Loaders re-evaluating on navigation is intended; the abort reaching `onReject` was the actual defect.

## Tests

- New unit test `abort rejection settles without calling onReject` (fails on `main`, passes here).
- Full suite green: 388 unit + 100 browser, no type errors. `route loader lazyness (abortable)` still passes.

Closes #1289
