### PR TITLE
docs(reatom-review): clarify status/retry defaults in summary

### DIFF
--- a/summary.md
+++ b/summary.md
@@ -111,11 +111,12 @@ Now we have extra atoms and actions to manage the list resource:
 
 - **list.data()**: the fetched list data
 - **list.ready()**: false by default and when the list is loading, true when the list is loaded
+- **list.pending()**: number of in-flight calls
 - **list.error()**: the error if the list fetching failed
-- **list.status()**: union of loading / error / data states
-- **list.retry()**: retry the list fetching
+- **list.retry()**: retry the list fetching (computeds can retry without `cacheParams`)
 - **list.reset()**: reset the list fetch and data to the initial state
   > you can use `list.data.reset` separately to reset the data only
+- **list.status()**: union of loading / error / data states — **opt-in**, available only when extended with `{ status: true }`; otherwise use `.ready()` / `.pending()` / `.error()`
 
 Also withAsyncData used `withAbort` under the hood, that prevent race conditions.
 
@@ -162,10 +163,15 @@ const submit = action(async (payload: MyForm) => {
 
 Key points
 
-- **submit.error()**, **submit.status()**, **submit.retry()** - the same base atom and actions
+- **submit.error()** - the same base atom
 - **submit.ready()** true by default for withAsync
+- **submit.pending()** - number of in-flight calls
+- **submit.status()** - **opt-in**, requires `withAsync({ status: true })`; otherwise use `.ready()` / `.pending()` / `.error()`
+- **submit.retry()** - **opt-in for actions**, requires `withAsync({ cacheParams: true })`; without it `retry` throws at call time. Computeds (`withAsyncData`) can retry without this option.
 - **submit.onFulfill**, **submit.onReject**, **submit.onSettle** - additional actions for precise logging and tracking, that can be "hooked" with `withCallHook` for additional logic (available in `withAsyncData` too)
 - **withAsync** does not add abort by default, add **withAbort** if needed
+
+> Note: `.status()` is opt-in via `{ status: true }`; action `.retry()` is opt-in via `{ cacheParams: true }`. Both default to `false` for performance / memory reasons. See the reatom-review skill `SKILL.md` "common rewrites" section for the full rule.
 
 ## **wrap** rules
 

--- a/summary.md
+++ b/summary.md
@@ -111,12 +111,11 @@ Now we have extra atoms and actions to manage the list resource:
 
 - **list.data()**: the fetched list data
 - **list.ready()**: false by default and when the list is loading, true when the list is loaded
-- **list.pending()**: number of in-flight calls
 - **list.error()**: the error if the list fetching failed
 - **list.retry()**: retry the list fetching (computeds can retry without `cacheParams`)
 - **list.reset()**: reset the list fetch and data to the initial state
   > you can use `list.data.reset` separately to reset the data only
-- **list.status()**: union of loading / error / data states — **opt-in**, available only when extended with `{ status: true }`; otherwise use `.ready()` / `.pending()` / `.error()`
+- **list.status()**: union of loading / error / data states — **opt-in**, available only when extended with `{ status: true }`; otherwise use `.ready()` / `.error()`
 
 Also withAsyncData used `withAbort` under the hood, that prevent race conditions.
 
@@ -165,13 +164,12 @@ Key points
 
 - **submit.error()** - the same base atom
 - **submit.ready()** true by default for withAsync
-- **submit.pending()** - number of in-flight calls
-- **submit.status()** - **opt-in**, requires `withAsync({ status: true })`; otherwise use `.ready()` / `.pending()` / `.error()`
+- **submit.status()** - **opt-in**, requires `withAsync({ status: true })`; otherwise use `.ready()` / `.error()`
 - **submit.retry()** - **opt-in for actions**, requires `withAsync({ cacheParams: true })`; without it `retry` throws at call time. Computeds (`withAsyncData`) can retry without this option.
 - **submit.onFulfill**, **submit.onReject**, **submit.onSettle** - additional actions for precise logging and tracking, that can be "hooked" with `withCallHook` for additional logic (available in `withAsyncData` too)
 - **withAsync** does not add abort by default, add **withAbort** if needed
 
-> Note: `.status()` is opt-in via `{ status: true }`; action `.retry()` is opt-in via `{ cacheParams: true }`. Both default to `false` for performance / memory reasons. See the reatom-review skill `SKILL.md` "common rewrites" section for the full rule.
+> Note: `.status()` is opt-in via `{ status: true }`; action `.retry()` is opt-in for actions via `{ cacheParams: true }`. Both default to `false` for performance / memory reasons. See the reatom-review skill `SKILL.md` "common rewrites" section for the full rule.
 
 ## **wrap** rules
 


### PR DESCRIPTION
## Why

The `reatom-review` skill's `summary.md` and `SKILL.md` contradict each other on what an async target exposes by default.

Source of truth — `packages/core/src/async/withAsync.ts@v1001`:

- L25: `'status is turned off by default, you need to activate it explicitly in options'`
- L227-228: `status = false, cacheParams = false`
- L287-289: action `retry` throws `'You should enable params caching in the options to use retry.'` when `cacheParams` is off
- L170-176 (JSDoc): for atoms (computeds), `retry` works without `cacheParams`

`SKILL.md` correctly states this on lines 30-31. `summary.md` did not — its bullet lists implied `.status()` and action `.retry()` were available on bare `withAsyncData({ initState: [] })` / `withAsync()`. An agent following the summary would generate code that compiles but throws at runtime, and the same skill marks `summary.md` as canonical, so the mismatch is the more dangerous direction.

## What

Surgical edits to `summary.md` only (single source; `skills/**` and `.cursor/skills/**` are symlinks):

- `withAsyncData` example bullets: mark `list.status()` as **opt-in** (`{ status: true }`); annotate `list.retry()` that computeds retry without `cacheParams`; add `list.pending()` (always available).
- `withAsync` example bullets: split `submit.status()` and `submit.retry()` into their own bullets with the exact option requirement and a note that action `retry` throws at call time without `cacheParams`.
- Added a one-line clarifier pointing back to the `SKILL.md` 'common rewrites' rule so future drift is easier to catch.

No code or example snippets were changed — the recommended minimal usage stays exactly as the skill teaches it; only the bullet descriptions now match the actual API surface.

## Verified against

- `packages/core/src/async/withAsync.ts@v1001` (defaults + retry guard)
- `skills/reatom-review/SKILL.md` lines 30-31, 400-430, 726