### PR TITLE
feat(preact,react): forward element ref and handlers through bindField

### DIFF
--- a/packages/preact/src/bindField.test-d.tsx
+++ b/packages/preact/src/bindField.test-d.tsx
@@ -1,0 +1,46 @@
+import { type FieldElementRef, reatomForm } from '@reatom/core'
+import type { Ref } from 'preact'
+import { expectTypeOf, test } from 'vitest'
+
+import { bindField } from './'
+
+const form = reatomForm({ text: '', flag: false }, 'typeForm')
+
+test('text field: value is the field value, checked is undefined', () => {
+  const bound = bindField(form.fields.text)
+
+  expectTypeOf(bound.value).toEqualTypeOf<string>()
+  expectTypeOf(bound.checked).toEqualTypeOf<undefined>()
+  expectTypeOf(bound.error).toEqualTypeOf<string | undefined>()
+  expectTypeOf(bound.ref).parameters.toEqualTypeOf<[FieldElementRef | null]>()
+})
+
+test('boolean field: value is undefined, checked is boolean', () => {
+  const bound = bindField(form.fields.flag)
+
+  expectTypeOf(bound.value).toEqualTypeOf<undefined>()
+  expectTypeOf(bound.checked).toEqualTypeOf<boolean>()
+})
+
+test('bound props spread onto <input> without type errors', () => {
+  // must compile for a text field (uses `value`)...
+  expectTypeOf(<input {...bindField(form.fields.text)} />).toBeObject()
+  // ...and for a boolean field (uses `checked`)
+  expectTypeOf(
+    <input type="checkbox" {...bindField(form.fields.flag)} />,
+  ).toBeObject()
+})
+
+test('options accept passthrough handlers, callback and object refs', () => {
+  const objectRef: Ref<FieldElementRef> = { current: null }
+  bindField(form.fields.text, { ref: objectRef })
+
+  bindField(form.fields.text, {
+    ref: (element) => {
+      expectTypeOf(element).toEqualTypeOf<FieldElementRef | null>()
+    },
+    onChange: (value) => void value,
+    onBlur: (event) => void event,
+    onFocus: (event) => void event,
+  })
+})

--- a/packages/preact/src/bindField.test.tsx
+++ b/packages/preact/src/bindField.test.tsx
@@ -1,0 +1,244 @@
+import {
+  atom,
+  clearStack,
+  context,
+  rAF,
+  reatomForm,
+  take,
+  top,
+  wrap,
+} from '@reatom/core'
+import { type ComponentChildren, render } from 'preact'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { bindField, reatomComponent, reatomContext } from './'
+
+clearStack()
+
+const tick = async () => {
+  await wrap(take(rAF))
+  await wrap(take(rAF))
+}
+
+const getRoot = () => document.getElementById('root')!
+
+const mount = (node: ComponentChildren) => {
+  const root = getRoot()
+  render(
+    <reatomContext.Provider value={top()}>{node}</reatomContext.Provider>,
+    root,
+  )
+  return root
+}
+
+const getInput = () =>
+  document.querySelector('[data-testid="name"]') as HTMLInputElement
+
+const fireChange = (input: HTMLInputElement, value: string) => {
+  input.value = value
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+beforeEach(() => {
+  const root = document.createElement('div')
+  root.id = 'root'
+  document.body.append(root)
+})
+
+afterEach(() => {
+  getRoot().remove()
+})
+
+describe('bindField ref', () => {
+  test('writes the bound element into field.elementRef', () =>
+    context.start(async () => {
+      const form = reatomForm({ name: '' }, 'elemRefForm')
+      const Form = reatomComponent(
+        () => <input data-testid="name" {...bindField(form.fields.name)} />,
+        'Form',
+      )
+
+      mount(<Form />)
+      await wrap(tick())
+
+      expect(form.fields.name.elementRef()).toBe(getInput())
+    }))
+
+  test('exposes focus() through field.elementRef', () =>
+    context.start(async () => {
+      const form = reatomForm({ name: '' }, 'focusForm')
+      const Form = reatomComponent(
+        () => <input data-testid="name" {...bindField(form.fields.name)} />,
+        'Form',
+      )
+
+      mount(<Form />)
+      await wrap(tick())
+
+      const input = getInput()
+      expect(document.activeElement).not.toBe(input)
+
+      form.fields.name.elementRef()?.focus()
+      expect(document.activeElement).toBe(input)
+    }))
+
+  test('clears field.elementRef on unmount', () =>
+    context.start(async () => {
+      const form = reatomForm({ name: '' }, 'unmountForm')
+      const Form = reatomComponent(
+        () => <input data-testid="name" {...bindField(form.fields.name)} />,
+        'Form',
+      )
+
+      const root = mount(<Form />)
+      await wrap(tick())
+      expect(form.fields.name.elementRef()).toBeInstanceOf(HTMLInputElement)
+
+      render(null, root)
+      await wrap(tick())
+      expect(form.fields.name.elementRef()).toBeUndefined()
+    }))
+
+  test('forwards the element to a user callback ref', () =>
+    context.start(async () => {
+      const form = reatomForm({ name: '' }, 'fnRefForm')
+      const userRef = vi.fn()
+      const Form = reatomComponent(
+        () => (
+          <input
+            data-testid="name"
+            {...bindField(form.fields.name, { ref: userRef })}
+          />
+        ),
+        'Form',
+      )
+
+      const root = mount(<Form />)
+      await wrap(tick())
+
+      const input = getInput()
+      expect(userRef).toHaveBeenCalledWith(input)
+      expect(form.fields.name.elementRef()).toBe(input)
+
+      render(null, root)
+      await wrap(tick())
+      expect(userRef).toHaveBeenLastCalledWith(null)
+    }))
+
+  test('forwards the element to a user object ref', () =>
+    context.start(async () => {
+      const form = reatomForm({ name: '' }, 'objRefForm')
+      const userRef: { current: HTMLInputElement | null } = { current: null }
+      const Form = reatomComponent(
+        () => (
+          <input
+            data-testid="name"
+            {...bindField(form.fields.name, { ref: userRef })}
+          />
+        ),
+        'Form',
+      )
+
+      const root = mount(<Form />)
+      await wrap(tick())
+      expect(userRef.current).toBe(getInput())
+
+      render(null, root)
+      await wrap(tick())
+      expect(userRef.current).toBe(null)
+    }))
+
+  test('keeps a stable ref identity across re-renders (no churn)', () =>
+    context.start(async () => {
+      const form = reatomForm({ name: '' }, 'stableRefForm')
+      const bump = atom(0, 'bump')
+      const refSpy = vi.fn()
+      const boundRefs: Array<(element: any) => void> = []
+
+      const Form = reatomComponent(() => {
+        bump() // subscribe to force re-renders
+        // a brand new inline user ref identity on every render
+        const bound = bindField(form.fields.name, {
+          ref: (element) => refSpy(element),
+        })
+        boundRefs.push(bound.ref)
+        return <input data-testid="name" {...bound} />
+      }, 'Form')
+
+      const root = mount(<Form />)
+      await wrap(tick())
+
+      const input = getInput()
+      expect(refSpy).toHaveBeenCalledTimes(1)
+      expect(refSpy).toHaveBeenLastCalledWith(input)
+
+      bump.set(1)
+      await wrap(tick())
+
+      // stable identity -> the framework does not detach/reattach the ref
+      expect(new Set(boundRefs).size).toBe(1)
+      expect(refSpy).toHaveBeenCalledTimes(1) // no null -> element churn
+
+      render(null, root)
+      await wrap(tick())
+      expect(refSpy).toHaveBeenCalledTimes(2)
+      expect(refSpy).toHaveBeenLastCalledWith(null)
+    }))
+
+  test('calls the latest passthrough onBlur after re-render', () =>
+    context.start(async () => {
+      const form = reatomForm({ name: '' }, 'latestBlurForm')
+      const bump = atom(0, 'bump')
+      const calls: number[] = []
+      const boundBlurs: Array<() => void> = []
+
+      const Form = reatomComponent(() => {
+        const version = bump()
+        const bound = bindField(form.fields.name, {
+          onBlur: () => calls.push(version),
+        })
+        boundBlurs.push(bound.onBlur)
+        return <input data-testid="name" {...bound} />
+      }, 'Form')
+
+      mount(<Form />)
+      await wrap(tick())
+
+      bump.set(1)
+      await wrap(tick())
+
+      const input = getInput()
+      input.focus()
+      input.blur()
+      await wrap(tick())
+
+      expect(new Set(boundBlurs).size).toBe(1) // stable identity
+      expect(calls).toEqual([1]) // latest closure, not the stale 0
+    }))
+
+  test('updates the field and calls the passthrough onChange', () =>
+    context.start(async () => {
+      const form = reatomForm({ name: '' }, 'changeForm')
+      const changeSpy = vi.fn()
+      const Form = reatomComponent(
+        () => (
+          <input
+            data-testid="name"
+            {...bindField(form.fields.name, { onChange: changeSpy })}
+          />
+        ),
+        'Form',
+      )
+
+      mount(<Form />)
+      await wrap(tick())
+
+      const input = getInput()
+      fireChange(input, 'hello')
+      await wrap(tick())
+
+      expect(form.fields.name.value()).toBe('hello')
+      expect(input.value).toBe('hello')
+      expect(changeSpy).toHaveBeenCalledTimes(1)
+    }))
+})

--- a/packages/preact/src/bindField.ts
+++ b/packages/preact/src/bindField.ts
@@ -1,67 +1,118 @@
-import type { FieldAtom, Rec } from '@reatom/core'
+import type { FieldAtom, FieldElementRef, Rec } from '@reatom/core'
 import { abortVar, memoKey, notify, wrap } from '@reatom/core'
+import type { Ref } from 'preact'
 
 import { toPreact } from './signal'
 
-export function bindField<T = any>(
-  field: FieldAtom<any, T>,
+type ChangeArg<Value> =
+  | Value
+  | {
+      currentTarget: Value extends boolean
+        ? { checked: Value }
+        : { value: Value }
+    }
+  | Event
+
+export interface BindFieldOptions<Value = any> {
+  /** Called after the field state is updated, with the original change argument. */
+  onChange?: (value: ChangeArg<Value>) => void
+  /** Called after the field focus is released. */
+  onBlur?: (event?: FocusEvent) => void
+  /** Called after the field gains focus. */
+  onFocus?: (event?: FocusEvent) => void
+  /**
+   * The user element ref, called in addition to writing the element to
+   * `field.elementRef`. Accepts a callback ref or a ref object.
+   */
+  ref?: Ref<FieldElementRef>
+}
+
+type Handlers<Value> = {
+  onChange: (event: ChangeArg<Value>) => void
+  onBlur: (event?: FocusEvent) => void
+  onFocus: (event?: FocusEvent) => void
+  ref: (element: FieldElementRef | null) => void
+}
+
+export function bindField<Value = any>(
+  field: FieldAtom<any, Value>,
+  options?: BindFieldOptions<Value>,
 ): {
-  value: T
-  checked: T extends boolean ? boolean : undefined
-  onChange: (
-    value:
-      | T
-      | { currentTarget: T extends boolean ? { checked: T } : { value: T } }
-      | Event,
-  ) => void
+  value: Value extends boolean ? undefined : Value
+  checked: Value extends boolean ? boolean : undefined
+  onChange: (value: ChangeArg<Value>) => void
   onBlur: () => void
   onFocus: () => void
+  ref: (element: FieldElementRef | null) => void
   error: undefined | string
 } {
-  const create = () => {
-    const onChange = wrap((event: any) => {
-      const isEvent = !!event?.currentTarget?.addEventListener
-      const value = isEvent
-        ? event.currentTarget.type === 'checkbox'
-          ? event.currentTarget.checked
-          : event.currentTarget.value
-        : event
+  const memo = memoKey(field.name, () => ({
+    field,
+    controller: undefined as undefined | ReturnType<typeof abortVar.get>,
+    options: undefined as BindFieldOptions<Value> | undefined,
+    handlers: undefined as Handlers<Value> | undefined,
+  }))
+
+  // Keep the latest user options so the memoized wrappers below read fresh
+  // closures at call time instead of capturing a stale one at creation.
+  memo.options = options
+
+  const createHandlers = (): Handlers<Value> => {
+    const onChange = wrap((event: ChangeArg<Value>) => {
+      const target = (event as unknown as { currentTarget?: HTMLInputElement })
+        .currentTarget
+      const value = target?.addEventListener
+        ? ((target.type === 'checkbox'
+            ? target.checked
+            : target.value) as Value)
+        : (event as Value)
 
       field.change(value)
       notify()
+      memo.options?.onChange?.(event)
     })
 
-    const onBlur = wrap(() => {
+    const onBlur = wrap((event?: FocusEvent) => {
       field.focus.out()
       notify()
+      memo.options?.onBlur?.(event)
     })
-    const onFocus = wrap(() => {
+    const onFocus = wrap((event?: FocusEvent) => {
       field.focus.in()
       notify()
+      memo.options?.onFocus?.(event)
     })
 
-    const controller = abortVar.get()
+    const ref = wrap((element: FieldElementRef | null) => {
+      field.elementRef.set(element ?? undefined)
+      const userRef = memo.options?.ref
+      if (typeof userRef === 'function') userRef(element)
+      else if (userRef) userRef.current = element
+    })
 
-    return { onChange, onBlur, onFocus, field, controller }
+    return { onChange, onBlur, onFocus, ref }
   }
+
+  if (
+    !memo.handlers ||
+    memo.controller?.signal.aborted ||
+    memo.field !== field
+  ) {
+    memo.field = field
+    memo.controller = abortVar.get()
+    memo.handlers = createHandlers()
+  }
+
+  const { onChange, onBlur, onFocus, ref } = memo.handlers
 
   const value = toPreact(field.value).value
-
-  let ref = memoKey(field.name, () => ({
-    current: create(),
-  }))
-  if (ref.current.controller?.signal.aborted || ref.current.field !== field) {
-    ref.current = create()
-  }
-
-  const { onChange, onBlur, onFocus } = ref.current
-
   const { error } = toPreact(field.validation).value
 
   const result: Rec = {
     onChange,
     onBlur,
     onFocus,
+    ref,
     error,
   }
 

--- a/packages/preact/vitest.config.ts
+++ b/packages/preact/vitest.config.ts
@@ -7,6 +7,12 @@ export default defineConfig({
     sequence: { groupOrder: 17 },
     testTimeout: 5000,
     name: '@reatom/preact',
-    include: ['./src/**/*.test.ts'],
+    include: ['./src/**/*.test.ts', './src/**/*.test-d.tsx'],
+    typecheck: {
+      enabled: true,
+      tsconfig: './tsconfig.json',
+      include: ['./src/**/*.test-d.tsx'],
+      ignoreSourceErrors: true,
+    },
   },
 })

--- a/packages/react/src/bindField.test-d.tsx
+++ b/packages/react/src/bindField.test-d.tsx
@@ -1,0 +1,46 @@
+import { type FieldElementRef, reatomForm } from '@reatom/core'
+import type { Ref } from 'react'
+import { expectTypeOf, test } from 'vitest'
+
+import { bindField } from './'
+
+const form = reatomForm({ text: '', flag: false }, 'typeForm')
+
+test('text field: value is the field value, checked is undefined', () => {
+  const bound = bindField(form.fields.text)
+
+  expectTypeOf(bound.value).toEqualTypeOf<string>()
+  expectTypeOf(bound.checked).toEqualTypeOf<undefined>()
+  expectTypeOf(bound.error).toEqualTypeOf<string | undefined>()
+  expectTypeOf(bound.ref).parameters.toEqualTypeOf<[FieldElementRef | null]>()
+})
+
+test('boolean field: value is undefined, checked is boolean', () => {
+  const bound = bindField(form.fields.flag)
+
+  expectTypeOf(bound.value).toEqualTypeOf<undefined>()
+  expectTypeOf(bound.checked).toEqualTypeOf<boolean>()
+})
+
+test('bound props spread onto <input> without type errors', () => {
+  // must compile for a text field (uses `value`)...
+  expectTypeOf(<input {...bindField(form.fields.text)} />).toBeObject()
+  // ...and for a boolean field (uses `checked`)
+  expectTypeOf(
+    <input type="checkbox" {...bindField(form.fields.flag)} />,
+  ).toBeObject()
+})
+
+test('options accept passthrough handlers, callback and object refs', () => {
+  const objectRef: Ref<FieldElementRef> = { current: null }
+  bindField(form.fields.text, { ref: objectRef })
+
+  bindField(form.fields.text, {
+    ref: (element) => {
+      expectTypeOf(element).toEqualTypeOf<FieldElementRef | null>()
+    },
+    onChange: (value) => void value,
+    onBlur: (event) => void event,
+    onFocus: (event) => void event,
+  })
+})

--- a/packages/react/src/bindField.test.tsx
+++ b/packages/react/src/bindField.test.tsx
@@ -1,0 +1,247 @@
+import {
+  atom,
+  clearStack,
+  context,
+  rAF,
+  reatomForm,
+  take,
+  top,
+  wrap,
+} from '@reatom/core'
+import ReactDOM from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { bindField, reatomComponent, reatomContext } from './'
+
+clearStack()
+
+const tick = async () => {
+  await wrap(take(rAF))
+  await wrap(take(rAF))
+}
+
+const mount = (node: React.ReactNode) => {
+  const root = ReactDOM.createRoot(document.getElementById('root')!)
+  root.render(
+    <reatomContext.Provider value={top()}>{node}</reatomContext.Provider>,
+  )
+  return root
+}
+
+const getInput = () =>
+  document.querySelector('[data-testid="name"]') as HTMLInputElement
+
+// React tracks the input value internally, so set it through the native
+// setter before dispatching `input` to make React pick up the change.
+const setNativeValue = (input: HTMLInputElement, value: string) => {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    'value',
+  )!.set!
+  setter.call(input, value)
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+beforeEach(() => {
+  const root = document.createElement('div')
+  root.id = 'root'
+  document.body.append(root)
+})
+
+afterEach(() => {
+  document.getElementById('root')?.remove()
+})
+
+describe('bindField ref', () => {
+  test('writes the bound element into field.elementRef', () =>
+    context.start(async () => {
+      const form = reatomForm({ name: '' }, 'elemRefForm')
+      const Form = reatomComponent(
+        () => <input data-testid="name" {...bindField(form.fields.name)} />,
+        'Form',
+      )
+
+      mount(<Form />)
+      await wrap(tick())
+
+      expect(form.fields.name.elementRef()).toBe(getInput())
+    }))
+
+  test('exposes focus() through field.elementRef', () =>
+    context.start(async () => {
+      const form = reatomForm({ name: '' }, 'focusForm')
+      const Form = reatomComponent(
+        () => <input data-testid="name" {...bindField(form.fields.name)} />,
+        'Form',
+      )
+
+      mount(<Form />)
+      await wrap(tick())
+
+      const input = getInput()
+      expect(document.activeElement).not.toBe(input)
+
+      form.fields.name.elementRef()?.focus()
+      expect(document.activeElement).toBe(input)
+    }))
+
+  test('clears field.elementRef on unmount', () =>
+    context.start(async () => {
+      const form = reatomForm({ name: '' }, 'unmountForm')
+      const Form = reatomComponent(
+        () => <input data-testid="name" {...bindField(form.fields.name)} />,
+        'Form',
+      )
+
+      const root = mount(<Form />)
+      await wrap(tick())
+      expect(form.fields.name.elementRef()).toBeInstanceOf(HTMLInputElement)
+
+      root.unmount()
+      await wrap(tick())
+      expect(form.fields.name.elementRef()).toBeUndefined()
+    }))
+
+  test('forwards the element to a user callback ref', () =>
+    context.start(async () => {
+      const form = reatomForm({ name: '' }, 'fnRefForm')
+      const userRef = vi.fn()
+      const Form = reatomComponent(
+        () => (
+          <input
+            data-testid="name"
+            {...bindField(form.fields.name, { ref: userRef })}
+          />
+        ),
+        'Form',
+      )
+
+      const root = mount(<Form />)
+      await wrap(tick())
+
+      const input = getInput()
+      expect(userRef).toHaveBeenCalledWith(input)
+      expect(form.fields.name.elementRef()).toBe(input)
+
+      root.unmount()
+      await wrap(tick())
+      expect(userRef).toHaveBeenLastCalledWith(null)
+    }))
+
+  test('forwards the element to a user object ref', () =>
+    context.start(async () => {
+      const form = reatomForm({ name: '' }, 'objRefForm')
+      const userRef: { current: HTMLInputElement | null } = { current: null }
+      const Form = reatomComponent(
+        () => (
+          <input
+            data-testid="name"
+            {...bindField(form.fields.name, { ref: userRef })}
+          />
+        ),
+        'Form',
+      )
+
+      const root = mount(<Form />)
+      await wrap(tick())
+      expect(userRef.current).toBe(getInput())
+
+      root.unmount()
+      await wrap(tick())
+      expect(userRef.current).toBe(null)
+    }))
+
+  test('keeps a stable ref identity across re-renders (no churn)', () =>
+    context.start(async () => {
+      const form = reatomForm({ name: '' }, 'stableRefForm')
+      const bump = atom(0, 'bump')
+      const refSpy = vi.fn()
+      const boundRefs: Array<(element: any) => void> = []
+
+      const Form = reatomComponent(() => {
+        bump() // subscribe to force re-renders
+        // a brand new inline user ref identity on every render
+        const bound = bindField(form.fields.name, {
+          ref: (element) => refSpy(element),
+        })
+        boundRefs.push(bound.ref)
+        return <input data-testid="name" {...bound} />
+      }, 'Form')
+
+      const root = mount(<Form />)
+      await wrap(tick())
+
+      const input = getInput()
+      expect(refSpy).toHaveBeenCalledTimes(1)
+      expect(refSpy).toHaveBeenLastCalledWith(input)
+
+      bump.set(1)
+      await wrap(tick())
+
+      // stable identity -> the framework does not detach/reattach the ref
+      expect(new Set(boundRefs).size).toBe(1)
+      expect(refSpy).toHaveBeenCalledTimes(1) // no null -> element churn
+
+      root.unmount()
+      await wrap(tick())
+      expect(refSpy).toHaveBeenCalledTimes(2)
+      expect(refSpy).toHaveBeenLastCalledWith(null)
+    }))
+
+  test('calls the latest passthrough onBlur after re-render', () =>
+    context.start(async () => {
+      const form = reatomForm({ name: '' }, 'latestBlurForm')
+      const bump = atom(0, 'bump')
+      const calls: number[] = []
+      const boundBlurs: Array<() => void> = []
+
+      const Form = reatomComponent(() => {
+        const version = bump()
+        const bound = bindField(form.fields.name, {
+          onBlur: () => calls.push(version),
+        })
+        boundBlurs.push(bound.onBlur)
+        return <input data-testid="name" {...bound} />
+      }, 'Form')
+
+      mount(<Form />)
+      await wrap(tick())
+
+      bump.set(1)
+      await wrap(tick())
+
+      const input = getInput()
+      input.focus()
+      input.blur()
+      await wrap(tick())
+
+      expect(new Set(boundBlurs).size).toBe(1) // stable identity
+      expect(calls).toEqual([1]) // latest closure, not the stale 0
+    }))
+
+  test('updates the field and calls the passthrough onChange', () =>
+    context.start(async () => {
+      const form = reatomForm({ name: '' }, 'changeForm')
+      const changeSpy = vi.fn()
+      const Form = reatomComponent(
+        () => (
+          <input
+            data-testid="name"
+            {...bindField(form.fields.name, { onChange: changeSpy })}
+          />
+        ),
+        'Form',
+      )
+
+      mount(<Form />)
+      await wrap(tick())
+
+      const input = getInput()
+      setNativeValue(input, 'hello')
+      await wrap(tick())
+
+      expect(form.fields.name.value()).toBe('hello')
+      expect(input.value).toBe('hello')
+      expect(changeSpy).toHaveBeenCalledTimes(1)
+    }))
+})

--- a/packages/react/src/bindField.ts
+++ b/packages/react/src/bindField.ts
@@ -1,66 +1,116 @@
-import type { FieldAtom, Rec } from '@reatom/core'
+import type { FieldAtom, FieldElementRef, Rec } from '@reatom/core'
 import { abortVar, memoKey, notify, wrap } from '@reatom/core'
-import type { ChangeEvent } from 'react'
+import type { ChangeEvent, FocusEvent, Ref } from 'react'
 
-export function bindField<T = any>(
-  field: FieldAtom<any, T>,
+type ChangeArg<Value> =
+  | Value
+  | {
+      currentTarget: Value extends boolean
+        ? { checked: Value }
+        : { value: Value }
+    }
+  | ChangeEvent<{ value: Value }>
+
+export interface BindFieldOptions<Value = any> {
+  /** Called after the field state is updated, with the original change argument. */
+  onChange?: (value: ChangeArg<Value>) => void
+  /** Called after the field focus is released. */
+  onBlur?: (event?: FocusEvent<Element>) => void
+  /** Called after the field gains focus. */
+  onFocus?: (event?: FocusEvent<Element>) => void
+  /**
+   * The user element ref, called in addition to writing the element to
+   * `field.elementRef`. Accepts a callback ref or a ref object.
+   */
+  ref?: Ref<FieldElementRef>
+}
+
+type Handlers<Value> = {
+  onChange: (event: ChangeArg<Value>) => void
+  onBlur: (event?: FocusEvent<Element>) => void
+  onFocus: (event?: FocusEvent<Element>) => void
+  ref: (element: FieldElementRef | null) => void
+}
+
+export function bindField<Value = any>(
+  field: FieldAtom<any, Value>,
+  options?: BindFieldOptions<Value>,
 ): {
-  value: T extends boolean ? undefined : T
-  checked: T extends boolean ? boolean : undefined
-  onChange: (
-    value:
-      | T
-      | { currentTarget: T extends boolean ? { checked: T } : { value: T } }
-      | ChangeEvent<{ value: T }>,
-  ) => void
+  value: Value extends boolean ? undefined : Value
+  checked: Value extends boolean ? boolean : undefined
+  onChange: (value: ChangeArg<Value>) => void
   onBlur: () => void
   onFocus: () => void
+  ref: (element: FieldElementRef | null) => void
   error: undefined | string
 } {
-  const create = () => {
-    const onChange = wrap((event: any) => {
-      const isEvent = !!event?.currentTarget?.addEventListener
-      const value = isEvent
-        ? event.currentTarget.type === 'checkbox'
-          ? event.currentTarget.checked
-          : event.currentTarget.value
-        : event
+  const memo = memoKey(field.name, () => ({
+    field,
+    controller: undefined as undefined | ReturnType<typeof abortVar.get>,
+    options: undefined as BindFieldOptions<Value> | undefined,
+    handlers: undefined as Handlers<Value> | undefined,
+  }))
+
+  // Keep the latest user options so the memoized wrappers below read fresh
+  // closures at call time instead of capturing a stale one at creation.
+  memo.options = options
+
+  const createHandlers = (): Handlers<Value> => {
+    const onChange = wrap((event: ChangeArg<Value>) => {
+      const target = (event as unknown as { currentTarget?: HTMLInputElement })
+        .currentTarget
+      const value = target?.addEventListener
+        ? ((target.type === 'checkbox'
+            ? target.checked
+            : target.value) as Value)
+        : (event as Value)
 
       field.change(value)
       notify()
+      memo.options?.onChange?.(event)
     })
 
-    const onBlur = wrap(() => {
+    const onBlur = wrap((event?: FocusEvent<Element>) => {
       field.focus.out()
       notify()
+      memo.options?.onBlur?.(event)
     })
-    const onFocus = wrap(() => {
+    const onFocus = wrap((event?: FocusEvent<Element>) => {
       field.focus.in()
       notify()
+      memo.options?.onFocus?.(event)
     })
 
-    const controller = abortVar.get()
+    const ref = wrap((element: FieldElementRef | null) => {
+      field.elementRef.set(element ?? undefined)
+      const userRef = memo.options?.ref
+      if (typeof userRef === 'function') userRef(element)
+      else if (userRef) userRef.current = element
+    })
 
-    return { onChange, onBlur, onFocus, field, controller }
+    return { onChange, onBlur, onFocus, ref }
   }
+
+  if (
+    !memo.handlers ||
+    memo.controller?.signal.aborted ||
+    memo.field !== field
+  ) {
+    memo.field = field
+    memo.controller = abortVar.get()
+    memo.handlers = createHandlers()
+  }
+
+  const { onChange, onBlur, onFocus, ref } = memo.handlers
 
   const value = field.value()
-
-  let ref = memoKey(field.name, () => ({
-    current: create(),
-  }))
-  if (ref.current.controller?.signal.aborted || ref.current.field !== field) {
-    ref.current = create()
-  }
-
-  const { onChange, onBlur, onFocus } = ref.current
-
   const { error } = field.validation()
 
   const result: Rec = {
     onChange,
     onBlur,
     onFocus,
+    ref,
     error,
   }
 

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -7,7 +7,13 @@ export default defineConfig({
   test: {
     sequence: { groupOrder: 14 },
     testTimeout: 5000,
-    include: ['./src/**/*.test.tsx'],
+    include: ['./src/**/*.test.tsx', './src/**/*.test-d.tsx'],
+    typecheck: {
+      enabled: true,
+      tsconfig: './tsconfig.json',
+      include: ['./src/**/*.test-d.tsx'],
+      ignoreSourceErrors: true,
+    },
     browser: {
       enabled: true,
       provider: playwright(),


### PR DESCRIPTION
## What

`bindField` now accepts an optional second argument and forwards the bound DOM element through a `ref`, in addition to passing through the user's own handlers — for both `@reatom/react` and `@reatom/preact`.

```tsx
<input {...bindField(form.fields.email, {
  ref: myRef,            // callback ref or { current } object ref
  onChange: handleChange,
  onBlur: handleBlur,
  onFocus: handleFocus,
})} />
```

The `ref` writes the element into the existing `field.elementRef` atom (so the built-in autofocus / scroll-to-error recipe works out of the box) **and** forwards it to the user-provided ref.

## How

- The bound `ref`/`onChange`/`onBlur`/`onFocus` are memoized once (via `memoKey`) so their identities stay referentially stable across re-renders — no callback-ref churn (`null → element` on every render).
- The latest user options are stored in the memo box and read at call time, so the stable wrappers always invoke the freshest passthrough closures without hooks.
- `field.elementRef.set(element ?? undefined)` on attach/detach; the user ref (function or object) is forwarded too.
- Aligns the Preact return `value` type with React's conditional (`Value extends boolean ? undefined : Value`) so boolean (checkbox) fields spread onto `<input>` without type errors — the runtime already only sets `checked` for booleans.

## Tests

- Browser tests (Vitest + Playwright, Chromium) for both packages: element exposed via `field.elementRef`, programmatic `focus()`, cleanup on unmount, callback- and object-ref forwarding, **stable ref identity across re-renders (no churn)**, latest-closure passthrough handlers, and value updates through `onChange`.
- Type tests (`*.test-d.tsx`, vitest `typecheck`) covering string vs boolean return shapes and that the bound props spread onto `<input>` / `<input type="checkbox">` without type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
