### PR TITLE
fix(core): withSuspenseInit restores frame via _copy so a later .set heals subscribers

### DIFF
--- a/packages/core/src/extensions/withSuspense.test.ts
+++ b/packages/core/src/extensions/withSuspense.test.ts
@@ -179,3 +179,34 @@ test('correct handling of immediate sync throw of promise', async () => {
 
   await wrap(expect(suspenseRetry(otherSuspenseAtom)).resolves.toBe(true))
 })
+
+test('sync-thrown suspense atom healed via .set notifies passive subscribers', async () => {
+  const client = computed(async () => {
+    await wrap(sleep())
+    return 'CLIENT'
+  }).extend(withSuspense())
+
+  const query = atom(() => {
+    client.suspended()
+    return 'initial'
+  }).extend(withSuspenseInit())
+
+  const consumer = computed(() => {
+    try {
+      return query()
+    } catch (error) {
+      if (error instanceof Promise) return 'PENDING'
+      throw error
+    }
+  })
+
+  const track = subscribe(consumer)
+  expect(track).toHaveBeenCalledWith('PENDING')
+
+  await wrap(sleep())
+  query.set('DATA')
+  notify()
+  await wrap(sleep())
+
+  expect(track).toHaveBeenCalledWith('DATA')
+})

--- a/packages/core/src/extensions/withSuspense.ts
+++ b/packages/core/src/extensions/withSuspense.ts
@@ -1,5 +1,6 @@
 import type { Atom, AtomLike, AtomState, Computed, Ext } from '../core'
 import {
+  _copy,
   _createGlobal,
   _set,
   AtomInitState,
@@ -300,9 +301,10 @@ export let withSuspenseInit: {
                 initState instanceof AtomInitState &&
                 frame.state === undefined
               ) {
-                frame.state = initState
-                frame.error = null
-                frame.pubs = [null]
+                let restored = _copy(frame)
+                restored.state = initState
+                restored.error = null
+                restored.pubs = [null]
               }
 
               throw error


### PR DESCRIPTION
## Problem

A `withSuspenseInit` atom whose body throws a suspense promise **synchronously** (e.g. by reading a suspending dependency) and is later healed via `.set()` never re-invalidates its **passive subscribers** — they stay stuck on the pending value forever.

The control case (an atom that *returns* a promise instead of throwing one synchronously) heals correctly, which isolates the trigger to the synchronous throw.

## Root cause

The `'read'` middleware of `withSuspenseInit` restores the frame **in place**:

```ts
frame.state = initState
frame.error = null
frame.pubs = [null]   // <- marks the frame `dirty` (pubs[0] === null)
```

A later healing `.set` goes through `cacheMiddleware`, where the copy-on-write
`if (!dirty) STACK[…] = frame = _copy(frame)` is **skipped** because the frame is already `dirty`. So the frame **keeps its identity**. Subscribers hold that frame as a pub snapshot, `_isPubsChanged` then compares the snapshot to the same object → "unchanged" → subscribers are never notified.

The existing `correct handling of immediate sync throw of promise` test passes only because it re-pulls **actively** (`suspenseRetry`); a passive subscriber exposes the bug.

## Fix

Restore through `_copy(frame)` (whose `store.set` side effect installs a **fresh** frame) instead of mutating the live frame in place, so the heal yields a new frame identity and subscribers are re-invalidated.

## Test

Adds a regression test: a sync-thrown suspense atom healed via `.set` notifies its passive subscribers. Red before the fix, green after. Full `@reatom/core` unit suite stays green (no regressions).