### PR TITLE
fix(core): catch up reatomAbstractRender on first subscribe

### DIFF
--- a/packages/core/src/reatomAbstractRender.test.ts
+++ b/packages/core/src/reatomAbstractRender.test.ts
@@ -1,0 +1,57 @@
+import { expect, test, vi } from 'test'
+
+import { atom, context, notify } from './core'
+import { reatomAbstractRender } from './reatomAbstractRender'
+
+test('mount subscription catches up when deps change before subscribe', () => {
+  context.start(() => {
+    const value = atom('pending', 'value')
+    const rerender = vi.fn()
+
+    const { render, mount } = reatomAbstractRender({
+      frame: context(),
+      render: () => value(),
+      rerender,
+      name: 'TestView',
+      abortOnUnmount: false,
+    })
+
+    expect(render({}).result).toBe('pending')
+
+    value.set('ok')
+
+    const unmount = mount()
+
+    expect(rerender).toHaveBeenCalledTimes(1)
+    expect(render({}).result).toBe('ok')
+
+    unmount()
+  })
+})
+
+test('mount subscription rerenders on later dep changes', () => {
+  context.start(() => {
+    const value = atom(0, 'value')
+    const rerender = vi.fn()
+
+    const { render, mount } = reatomAbstractRender({
+      frame: context(),
+      render: () => value(),
+      rerender,
+      name: 'TestView',
+      abortOnUnmount: false,
+    })
+
+    expect(render({}).result).toBe(0)
+
+    const unmount = mount()
+    rerender.mockClear()
+
+    value.set(1)
+    notify()
+
+    expect(rerender).toHaveBeenCalledTimes(1)
+
+    unmount()
+  })
+})

--- a/packages/core/src/reatomAbstractRender.ts
+++ b/packages/core/src/reatomAbstractRender.ts
@@ -148,7 +148,20 @@ export let reatomAbstractRender = <Props, Result>({
     let mount = bind(() => {
       recheckAbort(_read(_render)!)
 
+      // Catch up after subscribe: deps may change between render and mount
+      // (e.g. parent useLayoutEffect) while _render has no subscribers yet.
+      // The immediate subscribe callback must sync the host renderer; changedVar
+      // gate is for subsequent updates only.
+      let isFirstSubscriptionCall = true
+
       let unsubscribe = _render.subscribe((state) => {
+        if (isFirstSubscriptionCall) {
+          isFirstSubscriptionCall = false
+          changedVar.set(false)
+          rerender(state)
+          return
+        }
+
         let deps = 0
         if (
           changedVar.find((changed) =>

--- a/packages/react/src/reatomComponent.test.tsx
+++ b/packages/react/src/reatomComponent.test.tsx
@@ -7,10 +7,11 @@ import {
   rAF,
   take,
   top,
+  withAsyncData,
   withSuspenseInit,
   wrap,
 } from '@reatom/core'
-import React, { act, startTransition,Suspense } from 'react'
+import React, { act, startTransition, Suspense, useLayoutEffect } from 'react'
 import ReactDOM from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 
@@ -457,5 +458,49 @@ describe('reatomComponent', () => {
       expect(
         document.querySelector('[data-testid="result"]'),
       ).toBeInTheDocument()
+    }))
+
+  test('rerenders when async resource fulfills before mount subscription', () =>
+    context.start(async () => {
+      let resolve!: (value: string) => void
+      const promise = new Promise<string>((res) => {
+        resolve = res
+      })
+
+      const resource = computed(async () => promise, 'resource').extend(
+        withAsyncData(),
+      )
+
+      const BrokenView = reatomComponent(() => {
+        const data = resource.data()
+        const status = resource.status()
+
+        return (
+          <div data-testid="view">
+            {status.isPending ? 'loading' : `data: ${data}`}
+          </div>
+        )
+      }, 'BrokenView')
+
+      const Parent = () => {
+        useLayoutEffect(() => {
+          resolve('ok')
+        }, [])
+
+        return <BrokenView />
+      }
+
+      const root = ReactDOM.createRoot(document.getElementById('root')!)
+      root.render(
+        <reatomContext.Provider value={top()}>
+          <Parent />
+        </reatomContext.Provider>,
+      )
+
+      await wrap(tick())
+
+      expect(document.querySelector('[data-testid="view"]')?.textContent).toBe(
+        'data: ok',
+      )
     }))
 })


### PR DESCRIPTION
## Summary

Fixes a regression where `reatomComponent` can stay stuck in `loading` even though an async resource is already fulfilled in the store.

**Regression boundary:** `@reatom/core@1000.15.2` → `@reatom/core@1001.0.0` (not introduced in `1001.1.0`).

**Root cause commit:** [`fe76e2a8`](https://github.com/reatom/reatom/commit/fe76e2a8a6638353c289ae8c9197170b1e8da0dc) — `feat(core)!: subscriptions refactoring` (released in `1001.0.0`).

### What broke

In `1000.15.2`, `_render.subscribe(cb)` wrapped the callback in a computed:

```ts
computed(() => {
  userCb(this())
}, `${name}._subscribe`).subscribe()
```

The callback ran inside a computed context that reactively read `_render()`, so `changedVar.find(...)` in `reatomAbstractRender.mount` worked correctly.

In `1001.0.0`, the computed wrapper was removed and `atom.subscribe(cb)` now calls `userCb(frame.state)` **immediately** on subscribe. `reatomAbstractRender` was not updated for this semantics change.

### Race condition

1. Initial React render — `reatomComponent` calls `render()` with `rendering = true`, component reads async resource → DOM shows `loading`.
2. Between render and `useEffect` mount — resource can fulfill (e.g. parent `useLayoutEffect`, macOS workspace switch / background tab timing, fast network).
3. Store is up to date, but `_render` has **no subscribers yet** → `adapterRender` is not re-run.
4. `mount()` in `useEffect` — `_render.subscribe()` fires immediate callback.
5. Callback is filtered by `changedVar.find(...)` gate → `rerender` is never called → React stays on stale `loading`.

`useAtom(resource.data)` works because it uses `useSyncExternalStore(sub, get, get)` and re-reads atoms on every render.

### Fix

Always trigger a host rerender on the **first** subscribe callback (catch-up sync), then keep `changedVar` gate for subsequent updates:

```ts
let isFirstSubscriptionCall = true

_render.subscribe((state) => {
  if (isFirstSubscriptionCall) {
    isFirstSubscriptionCall = false
    changedVar.set(false)
    rerender(state)
    return
  }
  // ... existing changedVar gate
})
```

This restores catch-up behavior similar to `useSyncExternalStore` without reverting the `1001` subscribe API.

Fix is in `@reatom/core` → automatically covers React, Preact, and Lit adapters.

### Related investigation notes

- `@reatom/react` still uses `React.useEffect(mount, ...)` in both `1000.2.2` and `1001.0.0` — this is **not** a direct React adapter hook regression.
- Suspected commit `fb605fc` (`feat(react): optional render abort on unmount`) is **not** the root cause; `reatomAbstractRender.ts` mount subscription gate was unchanged across that boundary.
- `abortOnUnmount: true` may mask some related races in real apps but does not fix this subscribe catch-up issue.

### Reproduction

**Minimal repro (same code, different Reatom versions):**

- Working (`1000.15.2` / `1000.2.2`): https://stackblitz.com/edit/github-jh1xnwds?file=src%2Fapp.tsx
- Broken (`1001.1.0` / `1001.0.0`): https://stackblitz.com/edit/github-w66jezrk?file=src%2Fapp.tsx

**Real-world trigger:** refresh page → skeleton/loading appears → switch macOS workspace so browser goes to background → return → some sections stay in `loading` forever while requests already completed.

**Minimal pattern:**

```tsx
const BrokenView = reatomComponent(() => {
  const data = resource.data()
  const status = resource.status()
  return <div>{status.isPending ? 'loading' : `data: ${data}`}</div>
}, 'BrokenView')
```

Parent resolves resource promise in `useLayoutEffect`, so fulfillment happens after initial render/commit but before `reatomComponent`'s passive mount subscription.

## Test plan

- [x] `packages/core/src/reatomAbstractRender.test.ts` — unit tests for catch-up before subscribe and subsequent dep changes
- [x] `packages/react/src/reatomComponent.test.tsx` — integration test with `useLayoutEffect` + async resource
- [x] Full `@reatom/core` unit suite passes (`pnpm run test:unit` in `packages/core`)
```

---

## Изменённые файлы

| Файл | Что |
|------|-----|
| `packages/core/src/reatomAbstractRender.ts` | `isFirstSubscriptionCall` catch-up на первом subscribe |
| `packages/core/src/reatomAbstractRender.test.ts` | unit-тесты (новый файл) |
| `packages/react/src/reatomComponent.test.tsx` | интеграционный тест с async resource |
