### PR TITLE
fix(react): don't crash useAtom(value, deps) with primitive initial value

### DIFF
--- a/packages/react/src/hooks.test.tsx
+++ b/packages/react/src/hooks.test.tsx
@@ -100,6 +100,51 @@ describe('useAtom', () => {
       )
     }))
 
+  test('creates local atom from primitive with a deps array', () =>
+    context.start(async () => {
+      const keyAtom = atom('a', 'key')
+
+      const Counter = () => {
+        const [key] = useAtom(keyAtom)
+        // primitive initial value + non-empty deps array (overload 3) must
+        // not throw on first render
+        const [count, setCount] = useAtom(10, [key])
+        return (
+          <div>
+            <div data-testid="count">{count}</div>
+            <button
+              data-testid="increment"
+              onClick={() => setCount((c) => c + 1)}
+            >
+              Increment
+            </button>
+          </div>
+        )
+      }
+
+      const root = ReactDOM.createRoot(document.getElementById('root')!)
+      root.render(
+        <reatomContext.Provider value={top()}>
+          <Counter />
+        </reatomContext.Provider>,
+      )
+
+      await wrap(tick())
+      expect(document.querySelector('[data-testid="count"]')?.textContent).toBe(
+        '10',
+      )
+
+      const button = document.querySelector(
+        '[data-testid="increment"]',
+      ) as HTMLButtonElement
+      button.click()
+      await wrap(tick())
+
+      expect(document.querySelector('[data-testid="count"]')?.textContent).toBe(
+        '11',
+      )
+    }))
+
   test('creates local computed atom', () =>
     context.start(async () => {
       const baseAtom = atom(5, 'base')

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -94,17 +94,13 @@ export const useAtom: {
   ref.anAtom = anAtom
   const { theAtom, depsAtom, update, sub, get } = ref
 
-  if (!isAtom(anAtom)) {
+  if (typeof anAtom === 'function' && !isAtom(anAtom)) {
     const prevDeps = frame.run(depsAtom)
     if (
       userDeps.length !== prevDeps.length ||
       userDeps.some((dep, i) => !Object.is(dep, prevDeps[i]))
     ) {
-      if (theAtom.set) {
-        update?.(theAtom)
-      } else {
-        frame.run(depsAtom.set, userDeps)
-      }
+      frame.run(depsAtom.set, userDeps)
     }
   }
 


### PR DESCRIPTION
Fixes #1304.

## Problem

`useAtom(initState, deps?, options?)` (the primitive overload) throws
`Can't call atom "" with arguments, use .set instead` on the **first** render
when a non-empty deps array is passed:

```tsx
const [key] = useAtom(atom('a'))
const [count, setCount] = useAtom(10, [key]) // throws on first render
```

## Cause

The deps-reconciliation block in `packages/react/src/hooks.ts` ran for any
non-atom input. For a primitive, `theAtom = atom(anAtom)` has a `set`, so the
`if (theAtom.set) update?.(theAtom)` branch ran — and `update` is
`(...a) => { theAtom.set(...a); notify() }`, so the call became
`theAtom.set(theAtom)`. `set` treats the function argument as an updater and
invokes `theAtom(prev)`, which core rejects. `prevDeps` starts as `[]`, so any
non-empty deps array trips it on the first render.

`depsAtom` is only ever read by the inline `computed` created for the
function/computed overload, so this reconciliation is meaningless for
primitives.

## Fix

Scope the reconciliation to the function overload and drop the
crash-only primitive branch:

```diff
-  if (!isAtom(anAtom)) {
+  if (typeof anAtom === 'function' && !isAtom(anAtom)) {
     const prevDeps = frame.run(depsAtom)
     if (/* deps changed */) {
-      if (theAtom.set) {
-        update?.(theAtom)
-      } else {
-        frame.run(depsAtom.set, userDeps)
-      }
+      frame.run(depsAtom.set, userDeps)
     }
   }
```

For the function overload behavior is unchanged (`depsAtom.set(userDeps)`). For
a primitive, `useAtom` now behaves like `useState` — deps are ignored instead
of crashing.

## Tests

Added a regression test (`creates local atom from primitive with a deps array`)
that renders `useAtom(10, [key])`, asserts it does not throw, the value renders,
and the setter still works. The full `@reatom/react` suite passes (36 tests),
and `prettier --check` is clean.
