### PR TITLE
fix(react): subscribe to mount via useLayoutEffect

### DIFF
--- a/packages/react/src/reatomComponent.ts
+++ b/packages/react/src/reatomComponent.ts
@@ -133,7 +133,18 @@ export let reatomComponent = <Props extends Rec = {}>(
       [frame, ...deps.map((dep) => props[dep])],
     )
 
-    React.useEffect(mount, [mount, ...deps.map((dep) => props[dep])])
+    // useLayoutEffect (not useEffect): it runs synchronously during React's
+    // commit phase, before the call stack unwinds and the JS engine drains
+    // the microtask queue. A dependency with no real async I/O (e.g. a route
+    // loader or a `computed(async () => ...)` with nothing to await) resolves
+    // via pure microtasks and can finish -- updating the whole reactive graph
+    // -- before a `useEffect`-scheduled `mount()` ever gets to subscribe.
+    // `_render`'s own staleness flag is only set on a reactive recompute,
+    // which requires an active subscriber, so a change that completes before
+    // subscribing is missed forever and the component is stuck on its
+    // pre-resolution render permanently. useLayoutEffect closes that race
+    // window instead of narrowing it.
+    React.useLayoutEffect(mount, [mount, ...deps.map((dep) => props[dep])])
 
     let { result } = render(props)
     if (isSuspense(result)) {


### PR DESCRIPTION
Fixes #1311

## What

`reatomComponent`'s `mount()` -- which calls `_render.subscribe(...)`, the bridge that turns a Reatom dependency change into a React re-render -- subscribed via `React.useEffect`. This patches it to `React.useLayoutEffect`.

## Why

`useEffect` runs *after* commit, once the JS engine has already fully drained the microtask queue for the current task. A dependency with no real async I/O -- a `reatomRoute` `loader` with no `await`, or a `computed(async () => ...)` wrapping synchronous work -- resolves via pure microtasks and can finish, updating the whole reactive graph, *before* `mount()` ever gets to subscribe.

`reatomAbstractRender`'s own staleness flag (`changedVar`) is only set when the internal `_render` computed itself reactively recomputes, which requires an active subscriber. Since nothing is subscribed yet when the "instant" dependency resolves, `_render` never recomputes, `changedVar` never gets set, and the eventual (late) `subscribe()` call inside `mount()` sees a clean "nothing changed" state -- even though the update already happened and was missed. The component is stuck rendering its pre-resolution output forever.

`useLayoutEffect` runs synchronously during commit, before the call stack unwinds and the JS engine gets a chance to drain the microtask queue, so the subscription is always established before even a same-tick-resolving dependency can finish. Full writeup with a minimal repro in #1311.

## Testing

- `pnpm --filter @reatom/react test` -- all 35 tests pass, including `reatomComponent > rerenders when async resource fulfills before mount subscription` (added in 046bb38), which currently **fails** on `v1001` HEAD without this change (verified by reverting the one-line fix and re-running: `AssertionError: expected 'loading' to be 'data: ok'`).
- Verified against the standalone repro in #1311 (https://github.com/khmilevoi/reatom-react-mount-race-repro): both demo sections go from permanently stuck on "Loading..." to resolving immediately, in both `vite build`/`preview` and plain `vite dev`, in real Chrome.

## Scope

One line changed in `packages/react/src/reatomComponent.ts`, plus an explanatory comment. No other files touched -- `useLayoutEffect`'s only downside (a no-op-with-warning under SSR with no DOM) doesn't apply to `mount()`'s work here (an abort-controller recheck + a cheap `subscribe()` call), and this package has no SSR-specific code path to consider.
