### PR TITLE
fix(core): rebuild fieldArray from snapshot on reset after removal

### DIFF
--- a/packages/core/src/form/reatomFieldArray.test.ts
+++ b/packages/core/src/form/reatomFieldArray.test.ts
@@ -359,3 +359,48 @@ describe(`reactivity of validate function`, () => {
     expect(fieldArray.validation.errors()).toHaveLength(0)
   })
 })
+
+describe(`reset after element removal (#1309)`, () => {
+  const setup = (name: string) => {
+    const fieldArray = reatomFieldArray(['first', 'second', 'third'], { name })
+    const values = () => fieldArray.array().map((element) => element())
+    return { fieldArray, values }
+  }
+
+  const cases = [
+    { position: 'head', index: 0, afterRemove: ['second', 'third'] },
+    { position: 'middle', index: 1, afterRemove: ['first', 'third'] },
+    { position: 'tail', index: 2, afterRemove: ['first', 'second'] },
+  ]
+
+  for (const { position, index, afterRemove } of cases) {
+    test(`restores ${position} element`, () => {
+      const { fieldArray, values } = setup(`resetAfterRemoval.${position}`)
+
+      fieldArray.remove(fieldArray.array()[index]!)
+      notify()
+      expect(fieldArray().size).toBe(2)
+      expect(values()).toEqual(afterRemove)
+
+      fieldArray.reset()
+      notify()
+      expect(fieldArray().size).toBe(3)
+      expect(values()).toEqual(['first', 'second', 'third'])
+    })
+  }
+
+  test(`restores all elements after multiple removals`, () => {
+    const { fieldArray, values } = setup('resetAfterRemoval.multiple')
+
+    fieldArray.remove(fieldArray.array()[2]!)
+    fieldArray.remove(fieldArray.array()[0]!)
+    notify()
+    expect(fieldArray().size).toBe(1)
+    expect(values()).toEqual(['second'])
+
+    fieldArray.reset()
+    notify()
+    expect(fieldArray().size).toBe(3)
+    expect(values()).toEqual(['first', 'second', 'third'])
+  })
+})

--- a/packages/core/src/form/reatomFieldArray.ts
+++ b/packages/core/src/form/reatomFieldArray.ts
@@ -343,11 +343,14 @@ export function reatomFieldArray<Param, Node extends FieldsAtomizeInitState>(
     `${name}.onFieldCreated`,
   )
 
+  let currentInitSnapshot = initState as FieldArrayInitState<Param>[]
+
   const initStateAtom: This['initState'] = atom(
     () => fieldArrayAtom(),
     `${name}.initState`,
   ).extend(
     withParams((initState: FieldArrayInitState<Param>[]) => {
+      currentInitSnapshot = initState
       return fieldArrayAtom.initiateFromSnapshot(initState.map((v) => [v]))
     }),
   )
@@ -389,8 +392,15 @@ export function reatomFieldArray<Param, Node extends FieldsAtomizeInitState>(
     }),
   )
 
+  const baseReset = fieldArrayAtom.reset
+
   return Object.assign(fieldArrayAtom, {
     experimental_onFieldCreated: onFieldCreated,
+    reset: action(
+      (...args: [] | [initState: FieldArrayInitState<Param>[]]) =>
+        baseReset(...(args.length ? args : [currentInitSnapshot])),
+      `${name}._reset`,
+    ),
   })
 }
 


### PR DESCRIPTION
`reatomFieldArray`'s init snapshot shares node objects with the working
list. `remove`/`move`/`swap` mutate the nodes' linked-list pointers in
place, corrupting the frozen snapshot, so a bare `reset()` restored a
broken chain with a mismatched size. Route the no-arg reset through the
snapshot-rebuild path already used by `reset(values)`.

fix #1309