### PR TITLE
fix(transaction): rollback subscriber frame

### DIFF
--- a/packages/core/src/methods/transaction.test.ts
+++ b/packages/core/src/methods/transaction.test.ts
@@ -272,3 +272,22 @@ test('rollback survives an action invoked through a subscriber-created wrap', as
 
   unsubscribe()
 })
+
+test('a repeated rollback() must be a no-op, not an un-rollback', () => {
+  const counter = atom(0, 'counter').extend(withRollback())
+  const increment = action(() => {
+    counter.set((n) => n + 1)
+  }, 'increment').extend(withTransaction())
+
+  increment()
+  expect(counter()).toBe(1)
+
+  increment.rollback()
+  expect(counter()).toBe(0)
+
+  // Without the flush guard in withRollback, the rollback's own write would
+  // re-register an "undo of the undo" into the same (already drained) queue —
+  // and a repeated rollback() would re-apply the optimistic state.
+  increment.rollback()
+  expect(counter()).toBe(0)
+})

--- a/packages/core/src/methods/transaction.test.ts
+++ b/packages/core/src/methods/transaction.test.ts
@@ -237,3 +237,38 @@ test('stop clears rollback list without executing', () => {
   increment.rollback()
   expect(counter()).toBe(1)
 })
+
+test('rollback survives an action invoked through a subscriber-created wrap', async () => {
+  const like = atom(true, 'like').extend(withRollback())
+  const toggle = action(async () => {
+    like.set((state) => !state)
+    await wrap(sleep())
+    throw new Error('test')
+  }, 'like.toggle').extend(withTransaction())
+
+  // ≈ UI bindings (reatom-react): every state change re-renders, and the render re-creates
+  // the click handler via `wrap` INSIDE the subscription callback. Since subscribers run in
+  // the atom's live frame, the handler binds to it — so once a rollback becomes the atom's
+  // last writer, the next call's writes all satisfy `isCausedBy(transactionVar.rollback)`
+  // and withRollback silently skips registering their undos: the queue stays empty and the
+  // transaction has nothing to roll back. (The state the click left behind then makes the
+  // NEXT call clean again — in the UI this reads as rollback working every other click.)
+  let handler!: () => Promise<void>
+  const unsubscribe = like.subscribe(() => {
+    handler = wrap(async () => {
+      try {
+        await wrap(toggle())
+      } catch {
+        // the rollback is expected to have restored the state
+      }
+    })
+  })
+
+  await wrap(handler()) // 1st failing toggle → optimistic flip is rolled back
+  expect(like()).toBe(true)
+
+  await wrap(handler()) // 2nd failing toggle — must roll back the same way
+  expect(like()).toBe(true)
+
+  unsubscribe()
+})

--- a/packages/core/src/methods/transaction.ts
+++ b/packages/core/src/methods/transaction.ts
@@ -12,7 +12,6 @@ import {
 import { withCallHook } from '../extensions'
 import type { Fn } from '../utils'
 import { isAbort } from '../utils'
-import { isCausedBy } from './isCausedBy'
 import type { Variable } from './variable'
 import { variable } from './variable'
 
@@ -363,6 +362,35 @@ export let reatomTransaction = ({
     return undefined
   }
 
+  /**
+   * Whether the current write happens INSIDE this scope's rollback flush.
+   *
+   * Deliberately bounded, unlike `isCausedBy`: the walk stops at the nearest
+   * transaction boundary (the frame that owns a rollback queue). An unbounded
+   * ancestry check breaks UI bindings — subscriber callbacks run in the atom's
+   * live frame, so a handler `wrap`ped inside one (what reatom-react does on
+   * every render) keeps that frame in its chain. Once a rollback becomes the
+   * atom's last writer, every action invoked through such a handler would look
+   * "caused by rollback", silently skip all undo registration, and the next
+   * failure would have nothing to roll back (see the "subscriber-created wrap"
+   * test). A fresh transaction is a clean scope no matter what its caller's
+   * ancestry contains.
+   */
+  let isRollbackFlush = (frame: null | Frame = top()): boolean => {
+    let visited = new Set<Frame>()
+
+    while (frame && !visited.has(frame)) {
+      visited.add(frame)
+
+      if (frame.atom === (transactionVar.rollback as Atom)) return true
+      if (transactionVar.first(frame) !== undefined) return false
+
+      frame = frame.pubs[0]
+    }
+
+    return false
+  }
+
   let transactionVar = Object.assign(
     variable((rollbacks: Array<Fn> = []) => rollbacks, `transaction#${name}`),
     {
@@ -385,10 +413,7 @@ export let reatomTransaction = ({
                 let prevState = top().state
                 let nextState = next(...params)
 
-                if (
-                  !Object.is(prevState, nextState) &&
-                  !isCausedBy(transactionVar.rollback)
-                ) {
+                if (!Object.is(prevState, nextState) && !isRollbackFlush()) {
                   findRollbacks()?.push(() =>
                     target.set((state) =>
                       onRollback({


### PR DESCRIPTION
### Summary
`withRollback` can silently stop registering undos, so a failing `withTransaction` action rolls back nothing — but only for actions invoked through a callback that was created inside a subscriber (which is exactly what UI bindings like `@reatom/react` do on every render). In a real app this shows up as optimistic rollback working on every other interaction (works / stuck / works / stuck).

### Root cause
withRollback's middleware registers an undo for each state change unless the change is caused by the rollback flush itself (so the flush doesn't register an "undo of the undo"):

```ts
if (!Object.is(prevState, nextState) && !isCausedBy(transactionVar.rollback)) {
  findRollbacks()?.push(/* undo */)
}
```
The problem is that isCausedBy walks the entire cause ancestry. Two facts combine:

1. Subscriber callbacks run in the atom's live frame, so a function wrap()-ed inside a subscription binds to that frame — and the frame is a live object whose pubs are rewritten on every write.
2. After a rollback, the atom's last writer is transactionVar.rollback.

So an action invoked through such a subscriber-born handler has the rollback in its cause ancestry. Every optimistic write in that action then satisfies isCausedBy(transactionVar.rollback) → no undos are registered → the transaction's rollback queue is empty → the failure rolls back nothing. The stuck optimistic write then becomes the atom's last writer (a normal action, not a rollback), so the next call is "clean" and rolls back correctly — hence the strict alternation.

The guard is meant to answer "are we currently inside this scope's rollback flush?", but isCausedBy answers the much broader "is a rollback anywhere in this write's history?".

### The fix
Replace the unbounded isCausedBy(transactionVar.rollback) with a walk that stops at the nearest transaction boundary (the frame that owns a rollback queue):
```ts
let isRollbackFlush = (frame = top()): boolean => {
  let visited = new Set<Frame>()
  while (frame && !visited.has(frame)) {
    visited.add(frame)
    if (frame.atom === (transactionVar.rollback as Atom)) return true
    if (transactionVar.first(frame) !== undefined) return false // hit a transaction → clean scope
    frame = frame.pubs[0]
  }
  return false
}
```
The flush is still detected (its frame is reached before any transaction boundary), but a fresh transaction — started by withTransaction via transactionVar.set() — is a clean scope regardless of what its caller's ancestry contains.