### PR TITLE
feat(vite): add @reatom/vite for routing and JSX HMR

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/github-script@v8
         id: script
         env:
-          PACKAGE_FILE_REGEX: ^packages\/(?:core|react|jsx)\/
+          PACKAGE_FILE_REGEX: ^packages\/(?:core|react|jsx|vite)\/
 
         with:
           retries: 3
@@ -99,10 +99,10 @@ jobs:
         run: pnpm install
 
       - name: Build packages
-        run: pnpm --filter @reatom/react --filter @reatom/jsx run build
+        run: pnpm --filter @reatom/react --filter @reatom/jsx --filter @reatom/vite run build
 
       - name: Publish packages
-        run: pnpm dlx pkg-pr-new publish packages/core packages/react packages/jsx --packageManager=pnpm --pnpm
+        run: pnpm dlx pkg-pr-new publish packages/core packages/react packages/jsx packages/vite --packageManager=pnpm --pnpm
 
   publish-pr:
     timeout-minutes: 1
@@ -129,7 +129,7 @@ jobs:
         run: pnpm install
 
       - name: Build packages
-        run: pnpm --filter @reatom/react --filter @reatom/jsx run build
+        run: pnpm --filter @reatom/react --filter @reatom/jsx --filter @reatom/vite run build
 
       - name: Publish packages
-        run: pnpm dlx pkg-pr-new publish packages/core packages/react packages/jsx --packageManager=pnpm --pnpm
+        run: pnpm dlx pkg-pr-new publish packages/core packages/react packages/jsx packages/vite --packageManager=pnpm --pnpm

--- a/docs/astro.sidebar.ts
+++ b/docs/astro.sidebar.ts
@@ -148,6 +148,10 @@ export const sidebar = [
         link: '/reference/jsx',
       },
       {
+        label: '@reatom/vite',
+        link: '/reference/vite',
+      },
+      {
         label: '@reatom/zod',
         link: '/reference/zod',
       },

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -22,6 +22,7 @@ export const collections = {
         { path: 'packages/lit/src', mode: 'readme' },
         { path: 'packages/preact/src', mode: 'readme' },
         { path: 'packages/react/src', mode: 'readme' },
+        { path: 'packages/vite/src', mode: 'readme' },
         { path: 'packages/vue/src', mode: 'readme' },
         { path: 'packages/zod/src', mode: 'readme' },
       ],

--- a/docs/src/content/docs/handbook/routing.md
+++ b/docs/src/content/docs/handbook/routing.md
@@ -1233,7 +1233,18 @@ const route = reatomRoute({
 
 Child routes are registered on a plain `routes` object on the parent. The parent’s `outlet` computed does not automatically invalidate when that object is mutated, so after a hot update you can end up with a stale outlet until you drop the old child from the registry and force the parent outlet to recompute.
 
-In the route module (where `myRoute` is defined), you can use:
+Prefer [`@reatom/vite`](/reference/vite) — it injects this cleanup automatically in development:
+
+```ts title="vite.config.ts"
+import { defineConfig } from 'vite'
+import { reatom } from '@reatom/vite'
+
+export default defineConfig({
+  plugins: [reatom()],
+})
+```
+
+Or handle it manually in the route module (where `myRoute` is defined). Use `dispose` so the old route is removed _before_ the updated module registers the new one:
 
 ```typescript
 import { reatomRoute, retryComputed } from '@reatom/core'
@@ -1241,10 +1252,12 @@ import { reatomRoute, retryComputed } from '@reatom/core'
 const myRoute = reatomRoute({})
 
 if (import.meta.hot) {
-  import.meta.hot.accept(() => {
-    delete myRoute.parent!.routes[myRoute.name]
-    retryComputed(myRoute.parent!.outlet)
+  import.meta.hot.dispose(() => {
+    const parent = myRoute.parent
+    if (parent?.routes) delete parent.routes[myRoute.name]
+    if (parent && 'outlet' in parent) retryComputed(parent.outlet)
   })
+  import.meta.hot.accept()
 }
 ```
 

--- a/docs/src/content/docs/handbook/routing.md
+++ b/docs/src/content/docs/handbook/routing.md
@@ -1244,7 +1244,7 @@ export default defineConfig({
 })
 ```
 
-Or handle it manually in the route module (where `myRoute` is defined). Use `dispose` so the old route is removed _before_ the updated module registers the new one:
+Or handle it manually in the route module (where `myRoute` is defined). Use `dispose` so the old route is removed _before_ the updated module registers the new one, then `retryComputed` again after registration so the parent outlet sees the new child:
 
 ```typescript
 import { reatomRoute, retryComputed } from '@reatom/core'
@@ -1258,6 +1258,9 @@ if (import.meta.hot) {
     if (parent && 'outlet' in parent) retryComputed(parent.outlet)
   })
   import.meta.hot.accept()
+  if (myRoute.parent && 'outlet' in myRoute.parent) {
+    retryComputed(myRoute.parent.outlet)
+  }
 }
 ```
 

--- a/docs/src/content/docs/start/tooling.md
+++ b/docs/src/content/docs/start/tooling.md
@@ -72,6 +72,21 @@ LOG.extend(
 )
 ```
 
+## Vite
+
+[`@reatom/vite`](/reference/vite) injects development HMR cleanup for `reatomRoute` / nested `.reatomRoute()` and for `@reatom/jsx` `mount()`:
+
+```ts title="vite.config.ts"
+import { defineConfig } from 'vite'
+import { reatom } from '@reatom/vite'
+
+export default defineConfig({
+  plugins: [reatom()],
+})
+```
+
+See [routing HMR](/handbook/routing/#hot-module-replacement-vite) and [JSX HMR](/reference/jsx#hot-module-replacement-vite) for the underlying dispose pattern.
+
 ## Eslint
 
 We recommend using ESLint to enforce best practices and coding standards in your Reatom projects. We will publish our own ESLint plugin for name autofix soon, but you can use this plugin right now to automate `action`, `computed`, `effect` naming:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "postinstall": "pnpm --filter @reatom/core run build",
     "prepare": "git config blame.ignoreRevsFile .git-blame-ignore-revs && husky",
-    "test": "pnpm --filter @reatom/core --filter @reatom/react --filter @reatom/jsx --filter @reatom/zod run test",
+    "test": "pnpm --filter @reatom/core --filter @reatom/react --filter @reatom/jsx --filter @reatom/zod --filter @reatom/vite run test",
     "release": "tsx ./tools/publish.ts",
     "reset": "sh ./tools/reset.sh",
     "package-generator": "tsx tools/new-package.ts",

--- a/packages/vite/CHANGELOG.md
+++ b/packages/vite/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1001.0.0 (2026-07-19)
+
+### Feat
+
+- **vite**: Vite plugin for automatic routing and JSX HMR

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -1,0 +1,38 @@
+# @reatom/vite
+
+Vite plugin that automatically handles Reatom [routing HMR](https://www.reatom.dev/handbook/routing/#hot-module-replacement-vite) and [`@reatom/jsx` mount HMR](https://www.reatom.dev/reference/jsx#hot-module-replacement-vite).
+
+## Installation
+
+```sh
+npm install -D @reatom/vite
+```
+
+## Usage
+
+```ts
+import { defineConfig } from 'vite'
+import { reatom } from '@reatom/vite'
+
+export default defineConfig({
+  plugins: [reatom()],
+})
+```
+
+In development the plugin:
+
+1. **Routes** — tracks `reatomRoute(...)` / `parent.reatomRoute(...)` calls, then on hot dispose removes the old child from `parent.routes` / `urlAtom.routes` and `retryComputed(parent.outlet)` when the parent has an outlet.
+2. **JSX** — tracks `mount(...)` from `@reatom/jsx`, then on hot dispose calls `unmount()` so the re-executed module can mount a fresh tree.
+
+Modules that already contain `import.meta.hot` are left untouched so manual HMR keeps working.
+
+### Options
+
+```ts
+reatom({
+  routes: true, // default
+  jsx: true, // default
+  include: [/src\//],
+  exclude: [/stories\//],
+})
+```

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -21,7 +21,7 @@ export default defineConfig({
 
 In development the plugin:
 
-1. **Routes** — tracks `reatomRoute(...)` / `parent.reatomRoute(...)` calls, then on hot dispose removes the old child from `parent.routes` / `urlAtom.routes` and `retryComputed(parent.outlet)` when the parent has an outlet.
+1. **Routes** — tracks `reatomRoute(...)` / `parent.reatomRoute(...)` calls; on hot dispose removes the old child from `parent.routes` / `urlAtom.routes` and `retryComputed(parent.outlet)`, then retries the parent outlet again after each new route is registered (plain `routes` objects do not invalidate `outlet` on their own).
 2. **JSX** — tracks `mount(...)` from `@reatom/jsx`, then on hot dispose calls `unmount()` so the re-executed module can mount a fresh tree.
 
 Modules that already contain `import.meta.hot` are left untouched so manual HMR keeps working.

--- a/packages/vite/eslint.config.mjs
+++ b/packages/vite/eslint.config.mjs
@@ -1,0 +1,47 @@
+import simpleImportSort from 'eslint-plugin-simple-import-sort'
+import tsEslintPlugin from '@typescript-eslint/eslint-plugin'
+import tsEslintParser from '@typescript-eslint/parser'
+
+export default [
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tsEslintParser,
+      parserOptions: {
+        project: 'tsconfig.json',
+        tsconfigRootDir: import.meta.dirname,
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsEslintPlugin,
+      'simple-import-sort': simpleImportSort,
+    },
+    rules: {
+      'simple-import-sort/exports': 'error',
+      'simple-import-sort/imports': 'error',
+
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': ['error'],
+    },
+    settings: {
+      'import/resolver': {
+        typescript: {},
+      },
+    },
+  },
+  {
+    ignores: [
+      '*.config.js',
+      '*.d.ts',
+      '*.mjs',
+      'CHANGELOG.md',
+      'README.md',
+      'build',
+      'dist',
+      'node_modules',
+    ],
+  },
+]

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,0 +1,89 @@
+{
+  "name": "@reatom/vite",
+  "type": "module",
+  "version": "1001.0.0",
+  "private": false,
+  "sideEffects": false,
+  "description": "Vite plugin for Reatom routing and JSX hot module replacement",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "require": "./dist/index.cjs",
+    "default": "./dist/index.js"
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "browserslist": [
+    "last 1 year"
+  ],
+  "scripts": {
+    "prepublishOnly": "pnpm run build && pnpm run test",
+    "build": "tsdown",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "tsdown": {
+    "entry": [
+      "src/index.ts"
+    ],
+    "format": [
+      "esm",
+      "cjs"
+    ],
+    "fixedExtension": false,
+    "deps": {
+      "neverBundle": [
+        "magic-string",
+        "typescript"
+      ]
+    }
+  },
+  "peerDependencies": {
+    "@reatom/core": "workspace:^",
+    "vite": ">=5"
+  },
+  "peerDependenciesMeta": {
+    "@reatom/core": {
+      "optional": true
+    }
+  },
+  "dependencies": {
+    "magic-string": "^0.30.21",
+    "typescript": "catalog:"
+  },
+  "devDependencies": {
+    "@reatom/core": "workspace:^",
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  },
+  "author": "artalar",
+  "maintainers": [
+    {
+      "name": "artalar",
+      "url": "https://github.com/artalar"
+    }
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/reatom/reatom.git",
+    "directory": "packages/vite"
+  },
+  "bugs": {
+    "url": "https://github.com/reatom/reatom/issues"
+  },
+  "homepage": "https://www.reatom.dev/reference/vite",
+  "keywords": [
+    "vite",
+    "vite-plugin",
+    "hmr",
+    "routing",
+    "jsx",
+    "reatom"
+  ],
+  "files": [
+    "/dist"
+  ]
+}

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,0 +1,7 @@
+export { reatom, type ReatomViteOptions } from './plugin.ts'
+export {
+  isTransformTarget,
+  transformReatomModule,
+  type TransformOptions,
+  type TransformResult,
+} from './transform.ts'

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -1,0 +1,83 @@
+import type { Plugin } from 'vite'
+
+import { isTransformTarget, transformReatomModule } from './transform.ts'
+
+export type ReatomViteOptions = {
+  /**
+   * Inject route HMR cleanup for `reatomRoute` / `.reatomRoute()` calls.
+   *
+   * @default true
+   */
+  routes?: boolean
+  /**
+   * Inject JSX mount HMR cleanup for `mount()` from `@reatom/jsx`.
+   *
+   * @default true
+   */
+  jsx?: boolean
+  /**
+   * Additional picomatch patterns to include. Defaults to JS/TS modules outside
+   * `node_modules`.
+   */
+  include?: string | RegExp | Array<string | RegExp>
+  /** Picomatch patterns to exclude from the transform. */
+  exclude?: string | RegExp | Array<string | RegExp>
+}
+
+const matchesPattern = (
+  id: string,
+  pattern: string | RegExp | Array<string | RegExp> | undefined,
+  fallback: boolean,
+): boolean => {
+  if (pattern == null) return fallback
+  const patterns = Array.isArray(pattern) ? pattern : [pattern]
+  return patterns.some((entry) =>
+    typeof entry === 'string' ? id.includes(entry) : entry.test(id),
+  )
+}
+
+/**
+ * Vite plugin that wires Reatom routing and `@reatom/jsx` mount hot updates.
+ *
+ * Child routes register on a plain `routes` object; without cleanup a hot
+ * update can leave a stale parent `outlet`. JSX `mount()` trees also need
+ * `unmount()` before the module re-runs. This plugin injects that dispose logic
+ * automatically in development.
+ *
+ * @example
+ *   import { defineConfig } from 'vite'
+ *   import { reatom } from '@reatom/vite'
+ *
+ *   export default defineConfig({
+ *     plugins: [reatom()],
+ *   })
+ */
+export const reatom = (options: ReatomViteOptions = {}): Plugin => {
+  const routes = options.routes !== false
+  const jsx = options.jsx !== false
+
+  return {
+    name: '@reatom/vite',
+    apply: 'serve',
+    enforce: 'pre',
+    transform(code, id) {
+      if (!isTransformTarget(id)) return null
+      if (!matchesPattern(id, options.include, true)) return null
+      if (matchesPattern(id, options.exclude, false)) return null
+
+      const filename = id.split('?', 1)[0] ?? id
+      const result = transformReatomModule(code, {
+        routes,
+        jsx,
+        filename,
+      })
+
+      if (!result) return null
+
+      return {
+        code: result.code,
+        map: result.map,
+      }
+    },
+  }
+}

--- a/packages/vite/src/transform.test.ts
+++ b/packages/vite/src/transform.test.ts
@@ -32,6 +32,9 @@ export const homeRoute = layoutRoute.reatomRoute('')
     expect(result!.code).toContain(
       'delete __REATOM_VITE_urlAtom.routes[route.name]',
     )
+    expect(result!.code).toContain(
+      'if (route.parent && "outlet" in route.parent) __REATOM_VITE_retryComputed(route.parent.outlet)',
+    )
   })
 
   test('wraps mount from @reatom/jsx', () => {

--- a/packages/vite/src/transform.test.ts
+++ b/packages/vite/src/transform.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'vitest'
+
+import { transformReatomModule } from './transform.ts'
+
+describe('transformReatomModule', () => {
+  test('wraps reatomRoute and nested .reatomRoute calls', () => {
+    const input = `
+import { reatomRoute } from '@reatom/core'
+
+export const layoutRoute = reatomRoute({
+  path: 'app',
+  render: (self) => self.outlet(),
+})
+
+export const homeRoute = layoutRoute.reatomRoute('')
+`
+
+    const result = transformReatomModule(input, { filename: 'routes.ts' })
+    expect(result).not.toBeNull()
+    expect(result!.routes).toBe(true)
+    expect(result!.jsx).toBe(false)
+    expect(result!.code).toContain('__REATOM_VITE_trackRoute(reatomRoute({')
+    expect(result!.code).toContain(
+      "__REATOM_VITE_trackRoute(layoutRoute.reatomRoute(''))",
+    )
+    expect(result!.code).toContain('import.meta.hot.dispose')
+    expect(result!.code).toContain('import.meta.hot.accept()')
+    expect(result!.code).toContain(
+      'retryComputed as __REATOM_VITE_retryComputed',
+    )
+    expect(result!.code).toContain('delete parent.routes[route.name]')
+    expect(result!.code).toContain(
+      'delete __REATOM_VITE_urlAtom.routes[route.name]',
+    )
+  })
+
+  test('wraps mount from @reatom/jsx', () => {
+    const input = `
+import { mount } from '@reatom/jsx'
+import { App } from './App'
+
+const { unmount } = mount(document.getElementById('app')!, <App />)
+`
+
+    const result = transformReatomModule(input, { filename: 'main.tsx' })
+    expect(result).not.toBeNull()
+    expect(result!.jsx).toBe(true)
+    expect(result!.routes).toBe(false)
+    expect(result!.code).toContain('__REATOM_VITE_trackMount(mount(')
+    expect(result!.code).toContain('mounted.unmount()')
+    expect(result!.code).not.toContain('@reatom/core')
+  })
+
+  test('handles routes and mount in one module', () => {
+    const input = `
+import { reatomRoute } from '@reatom/core'
+import { mount } from '@reatom/jsx'
+
+const rootRoute = reatomRoute({ render: () => null })
+mount(document.body, <div />)
+`
+
+    const result = transformReatomModule(input, { filename: 'app.tsx' })
+    expect(result).not.toBeNull()
+    expect(result!.routes).toBe(true)
+    expect(result!.jsx).toBe(true)
+    expect(result!.code).toContain('__REATOM_VITE_trackRoute(reatomRoute({')
+    expect(result!.code).toContain('__REATOM_VITE_trackMount(mount(')
+  })
+
+  test('skips modules that already define import.meta.hot', () => {
+    const input = `
+import { reatomRoute } from '@reatom/core'
+const route = reatomRoute('x')
+if (import.meta.hot) import.meta.hot.accept()
+`
+    expect(transformReatomModule(input, { filename: 'routes.ts' })).toBeNull()
+  })
+
+  test('skips when routes and jsx options are disabled', () => {
+    const input = `
+import { reatomRoute } from '@reatom/core'
+import { mount } from '@reatom/jsx'
+const route = reatomRoute('x')
+mount(document.body, null)
+`
+    expect(
+      transformReatomModule(input, {
+        filename: 'app.tsx',
+        routes: false,
+        jsx: false,
+      }),
+    ).toBeNull()
+  })
+
+  test('does not wrap unrelated mount identifiers', () => {
+    const input = `
+import { atom } from '@reatom/core'
+
+const mount = () => {}
+mount()
+`
+    expect(transformReatomModule(input, { filename: 'x.ts' })).toBeNull()
+  })
+
+  test('tracks aliased mount imports', () => {
+    const input = `
+import { mount as mountApp } from '@reatom/jsx'
+mountApp(document.body, <div />)
+`
+    const result = transformReatomModule(input, { filename: 'main.tsx' })
+    expect(result).not.toBeNull()
+    expect(result!.code).toContain('__REATOM_VITE_trackMount(mountApp(')
+  })
+})

--- a/packages/vite/src/transform.ts
+++ b/packages/vite/src/transform.ts
@@ -1,0 +1,232 @@
+import MagicString from 'magic-string'
+import ts from 'typescript'
+
+export type TransformOptions = {
+  routes?: boolean
+  jsx?: boolean
+  filename?: string
+}
+
+export type TransformResult = {
+  code: string
+  map: { mappings: string }
+  routes: boolean
+  jsx: boolean
+}
+
+const ROUTE_TRACK = '__REATOM_VITE_trackRoute'
+const ROUTE_LIST = '__REATOM_VITE_routes'
+const MOUNT_TRACK = '__REATOM_VITE_trackMount'
+const MOUNT_LIST = '__REATOM_VITE_mounts'
+const RETRY = '__REATOM_VITE_retryComputed'
+const URL_ATOM = '__REATOM_VITE_urlAtom'
+
+const JS_EXT = /\.[cm]?[jt]sx?$/
+
+export const isTransformTarget = (id: string): boolean => {
+  const filename = id.split('?', 1)[0] ?? id
+  if (
+    filename.includes('/node_modules/') ||
+    filename.includes('\\node_modules\\')
+  ) {
+    return false
+  }
+  return JS_EXT.test(filename)
+}
+
+const scriptKindFor = (filename: string): ts.ScriptKind => {
+  if (filename.endsWith('.tsx')) return ts.ScriptKind.TSX
+  if (filename.endsWith('.jsx')) return ts.ScriptKind.JSX
+  if (
+    filename.endsWith('.js') ||
+    filename.endsWith('.mjs') ||
+    filename.endsWith('.cjs')
+  ) {
+    return ts.ScriptKind.JS
+  }
+  return ts.ScriptKind.TS
+}
+
+const getLocalNamesForExport = (
+  sourceFile: ts.SourceFile,
+  moduleSpecifier: string,
+  exportedName: string,
+): Set<string> => {
+  const names = new Set<string>()
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement)) continue
+    if (!ts.isStringLiteral(statement.moduleSpecifier)) continue
+    if (statement.moduleSpecifier.text !== moduleSpecifier) continue
+
+    const clause = statement.importClause
+    if (!clause?.namedBindings || !ts.isNamedImports(clause.namedBindings)) {
+      continue
+    }
+
+    for (const element of clause.namedBindings.elements) {
+      const importedName = element.propertyName?.text ?? element.name.text
+      if (importedName === exportedName) {
+        names.add(element.name.text)
+      }
+    }
+  }
+
+  return names
+}
+
+const isReatomRouteCall = (node: ts.CallExpression): boolean => {
+  const expression = node.expression
+  if (ts.isIdentifier(expression)) {
+    return expression.text === 'reatomRoute'
+  }
+  if (ts.isPropertyAccessExpression(expression)) {
+    return expression.name.text === 'reatomRoute'
+  }
+  return false
+}
+
+const isMountCall = (
+  node: ts.CallExpression,
+  mountNames: Set<string>,
+): boolean => {
+  if (!ts.isIdentifier(node.expression)) return false
+  return mountNames.has(node.expression.text)
+}
+
+const collectCallRanges = (
+  sourceFile: ts.SourceFile,
+  predicate: (node: ts.CallExpression) => boolean,
+): Array<{ start: number; end: number }> => {
+  const ranges: Array<{ start: number; end: number }> = []
+
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node) && predicate(node)) {
+      ranges.push({
+        start: node.getStart(sourceFile),
+        end: node.getEnd(),
+      })
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return ranges
+}
+
+const wrapCallsWithStarts = (
+  magicString: MagicString,
+  ranges: Array<{ start: number; end: number }>,
+  trackName: string,
+) => {
+  for (const range of ranges.toSorted(
+    (left, right) => right.start - left.start,
+  )) {
+    magicString.appendLeft(range.start, `${trackName}(`)
+    magicString.appendLeft(range.end, ')')
+  }
+}
+
+const buildRoutePreamble = (): string =>
+  `import { retryComputed as ${RETRY}, urlAtom as ${URL_ATOM} } from '@reatom/core';
+const ${ROUTE_LIST} = [];
+const ${ROUTE_TRACK} = (route) => (${ROUTE_LIST}.push(route), route);
+`
+
+const buildMountPreamble = (): string =>
+  `const ${MOUNT_LIST} = [];
+const ${MOUNT_TRACK} = (result) => (${MOUNT_LIST}.push(result), result);
+`
+
+const buildHotFooter = (routes: boolean, jsx: boolean): string => {
+  const disposeBody: string[] = []
+
+  if (routes) {
+    disposeBody.push(`
+    for (const route of ${ROUTE_LIST}) {
+      const parent = route.parent;
+      if (parent?.routes) delete parent.routes[route.name];
+      if (parent !== ${URL_ATOM}) delete ${URL_ATOM}.routes[route.name];
+      if (parent && "outlet" in parent) ${RETRY}(parent.outlet);
+    }
+    ${ROUTE_LIST}.length = 0;`)
+  }
+
+  if (jsx) {
+    disposeBody.push(`
+    for (const mounted of ${MOUNT_LIST}) mounted.unmount();
+    ${MOUNT_LIST}.length = 0;`)
+  }
+
+  return `
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {${disposeBody.join('')}
+  });
+  import.meta.hot.accept();
+}
+`
+}
+
+export const transformReatomModule = (
+  code: string,
+  options: TransformOptions = {},
+): TransformResult | null => {
+  const enableRoutes = options.routes !== false
+  const enableJsx = options.jsx !== false
+  const filename = options.filename ?? 'module.tsx'
+
+  if (code.includes('import.meta.hot')) return null
+
+  const wantsRoutes = enableRoutes && code.includes('reatomRoute')
+  const wantsJsxImport = enableJsx && code.includes('@reatom/jsx')
+
+  if (!wantsRoutes && !wantsJsxImport) return null
+
+  const sourceFile = ts.createSourceFile(
+    filename,
+    code,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKindFor(filename),
+  )
+
+  const mountNames = wantsJsxImport
+    ? getLocalNamesForExport(sourceFile, '@reatom/jsx', 'mount')
+    : new Set<string>()
+
+  const routeRanges = wantsRoutes
+    ? collectCallRanges(sourceFile, isReatomRouteCall)
+    : []
+  const mountRanges =
+    mountNames.size > 0
+      ? collectCallRanges(sourceFile, (node) => isMountCall(node, mountNames))
+      : []
+
+  const injectRoutes = routeRanges.length > 0
+  const injectJsx = mountRanges.length > 0
+
+  if (!injectRoutes && !injectJsx) return null
+
+  const magicString = new MagicString(code)
+
+  if (injectRoutes) {
+    wrapCallsWithStarts(magicString, routeRanges, ROUTE_TRACK)
+  }
+  if (injectJsx) {
+    wrapCallsWithStarts(magicString, mountRanges, MOUNT_TRACK)
+  }
+
+  let preamble = ''
+  if (injectRoutes) preamble += buildRoutePreamble()
+  if (injectJsx) preamble += buildMountPreamble()
+
+  magicString.prepend(preamble)
+  magicString.append(buildHotFooter(injectRoutes, injectJsx))
+
+  return {
+    code: magicString.toString(),
+    map: magicString.generateMap({ hires: true }),
+    routes: injectRoutes,
+    jsx: injectJsx,
+  }
+}

--- a/packages/vite/src/transform.ts
+++ b/packages/vite/src/transform.ts
@@ -130,7 +130,11 @@ const wrapCallsWithStarts = (
 const buildRoutePreamble = (): string =>
   `import { retryComputed as ${RETRY}, urlAtom as ${URL_ATOM} } from '@reatom/core';
 const ${ROUTE_LIST} = [];
-const ${ROUTE_TRACK} = (route) => (${ROUTE_LIST}.push(route), route);
+const ${ROUTE_TRACK} = (route) => {
+  ${ROUTE_LIST}.push(route);
+  if (route.parent && "outlet" in route.parent) ${RETRY}(route.parent.outlet);
+  return route;
+};
 `
 
 const buildMountPreamble = (): string =>

--- a/packages/vite/tsconfig.json
+++ b/packages/vite/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declarationMap": true,
+    "types": ["node"]
+  }
+}

--- a/packages/vite/vitest.config.ts
+++ b/packages/vite/vitest.config.ts
@@ -1,0 +1,10 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    sequence: { groupOrder: 20 },
+    testTimeout: 5000,
+    include: ['./src/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -958,6 +958,31 @@ importers:
         specifier: 'catalog:'
         version: 4.1.7(@types/node@25.5.0)(@vitest/browser-playwright@4.1.7)(@vitest/ui@4.1.7)(msw@2.12.13(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.14(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
 
+  packages/vite:
+    dependencies:
+      magic-string:
+        specifier: ^0.30.21
+        version: 0.30.21
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+    devDependencies:
+      '@reatom/core':
+        specifier: workspace:^
+        version: link:../core
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.19
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.21.2(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)(oxc-resolver@11.19.1(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0))(typescript@5.9.3)
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.14(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(@types/node@22.19.19)(@vitest/browser-playwright@4.1.7)(@vitest/ui@4.1.7)(msw@2.12.13(@types/node@22.19.19)(typescript@5.9.3))(vite@8.0.14(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+
   packages/vue:
     dependencies:
       '@reatom/core':

--- a/skills/reatom-jsx/REFERENCE.md
+++ b/skills/reatom-jsx/REFERENCE.md
@@ -36,8 +36,10 @@ For Vite users:
 
 ```js
 import { defineConfig } from 'vite'
+import { reatom } from '@reatom/vite'
 
 export default defineConfig({
+  plugins: [reatom()],
   esbuild: {
     jsxFactory: 'h',
     jsxFragment: 'hf',
@@ -45,6 +47,8 @@ export default defineConfig({
   },
 })
 ```
+
+`@reatom/vite` also wires routing and `mount()` hot updates — see [Hot module replacement](#hot-module-replacement-vite).
 
 ## Framework compatibility
 
@@ -113,16 +117,21 @@ The `mount` function returns an `unmount` property callback (similar to React's 
 
 ### Hot module replacement (Vite)
 
-During development, the bundler can replace a module without a full reload. The old DOM tree and Reatom subscriptions stay alive unless you tear them down. Call `unmount()` from the previous `mount` inside `import.meta.hot.accept` so the updated module can mount a fresh tree:
+During development, the bundler can replace a module without a full reload. The old DOM tree and Reatom subscriptions stay alive unless you tear them down.
+
+Prefer [`@reatom/vite`](https://www.reatom.dev/reference/vite) — add `reatom()` to your Vite plugins and `mount()` cleanup is injected automatically.
+
+Or handle it manually: call `unmount()` from the previous `mount` inside `import.meta.hot.dispose` so the updated module can mount a fresh tree:
 
 ```tsx
 const root = document.getElementById('app')!
 const { unmount } = mount(root, <App />)
 
 if (import.meta.hot) {
-  import.meta.hot.accept(() => {
+  import.meta.hot.dispose(() => {
     unmount()
   })
+  import.meta.hot.accept()
 }
 ```
 

--- a/skills/reatom-jsx/SKILL.md
+++ b/skills/reatom-jsx/SKILL.md
@@ -43,7 +43,7 @@ Use this map to open only the relevant parts of [REFERENCE.md](REFERENCE.md):
 - Form submit loader: style `[data-submitting]` on the form (set automatically by `model={form}`); CSS-only spinner on `[type='submit']::after`.
 - For SPA navigation use `reatomRoute`: links via `href={route.path(params)}`, programmatic moves via `route.go(params)` — see the `reatom` skill Routing section.
 - Use `prop:*` for DOM properties, `attr:*` for attributes when semantics matter.
-- Mount with `mount(root, <App />)`; call `unmount()` on teardown (including Vite HMR).
+- Mount with `mount(root, <App />)`; call `unmount()` on teardown (including Vite HMR). Prefer `@reatom/vite` (`reatom()` plugin) so mount/route HMR dispose is automatic.
 - For dynamic lists, store elements in atoms or map inside reactive children — no keyed reconciliation.
 
 When [REFERENCE.md](REFERENCE.md) and local examples disagree, prefer the reference and fix the example if it is wrong.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `@reatom/vite` — a Vite plugin that automatically handles the [routing HMR dispose pattern](https://www.reatom.dev/handbook/routing/#hot-module-replacement-vite) and `@reatom/jsx` `mount()` teardown in development.

```ts
import { defineConfig } from 'vite'
import { reatom } from '@reatom/vite'

export default defineConfig({
  plugins: [reatom()],
})
```

### Behavior

- **Routes:** wraps `reatomRoute(...)` / `.reatomRoute(...)` calls; on `import.meta.hot.dispose` removes the old child from `parent.routes` / `urlAtom.routes` and `retryComputed(parent.outlet)`; after re-registration, `trackRoute` retries the parent outlet again so it is not left empty/stale
- **JSX:** wraps `mount(...)` from `@reatom/jsx` and calls `unmount()` on dispose so the re-executed module can remount cleanly
- Skips modules that already define `import.meta.hot` (manual HMR wins)
- Dev-only (`apply: 'serve'`)

### Docs

- Handbook routing HMR section recommends the plugin; manual snippet updated to dispose + post-registration `retryComputed`
- JSX reference / skill and tooling page updated similarly
- Package wired into docs sidebar + jsdoc readme loader

### CI

- Included `packages/vite` in `.github/workflows/preview.yml` (change detection, build, and `pkg-pr-new` publish)

### Testing

- Unit tests for the transform (`pnpm --filter @reatom/vite test`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3405674e-fd17-4d97-9eb0-c2b7a15b539f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3405674e-fd17-4d97-9eb0-c2b7a15b539f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

