### PR TITLE
fix(withCache): deliver the cached value instead of an aborted call on a cache hit

### DIFF
--- a/packages/core/src/extensions/withCache.test.ts
+++ b/packages/core/src/extensions/withCache.test.ts
@@ -500,19 +500,10 @@ test('pending stays correct after a persist-hydrated cache hit under a computed 
 })
 
 test('remount after an SSR-hydrated cache hit must render, not throw the cache AbortError', async () => {
-  // Repro of a real navigation crash: land on a server-rendered page (hydration
-  // cache hit), route away, route back — the route's clientLoader awaits the
-  // query and the whole page falls into the error boundary with
-  // '<name>.query.withAbort cache [#N]'.
-  //
-  // Empirically pinned conditions:
-  // 1. the cache record must come from persist HYDRATION (SSR snapshot) — after
-  //    a live fetch on the same client the very same flow passes;
-  // 2. the crash needs a DIRECT `query()` call (what a route loader does): its
-  //    recomputation hits the hydrated cache, withCache aborts the call's own
-  //    `withAbort` controller with 'cache', and the returned promise REJECTS
-  //    with that AbortError instead of resolving with the cached value.
-  //    Render-only reads (`data()`/`pending()`) never throw.
+  // A persist-hydrated cache hit aborts the call's own withAbort controller and
+  // poisons the query state with a promise rejected by 'cache'. Render-style
+  // reads survive, but a direct `await query()` (a route loader on navigating
+  // back) throws it. A live-fetched cache record never reproduces this.
   const name = 'withCache.remount'
   const storage = createMemStorage({ name, subscribe: false })
   const withSSR = reatomPersist(storage)
@@ -539,7 +530,7 @@ test('remount after an SSR-hydrated cache hit must render, not throw the cache A
     return { cursor, query }
   }
 
-  // server: render the landing page → cache filled for the initial params → snapshot
+  // server: fill the cache, snapshot
   const snapshot = await wrap(
     context.start(async () => {
       const { query } = make()
@@ -554,27 +545,23 @@ test('remount after an SSR-hydrated cache hit must render, not throw the cache A
       const { query } = make()
       storage.snapshotAtom.set(snapshot)
 
-      // What reatom-react's `reatomComponent` does for a list view: an abstract
-      // render whose render function reads the async data and pending state.
+      // what reatom-react's `reatomComponent` does for a list view
       const mountView = () => {
         const view: AbstractRender<Rec, { data: string; pending: number }> =
           reatomAbstractRender({
             frame: top().root.frame,
             render: () => ({ data: query.data(), pending: query.pending() }),
-            // React: subscription → setState → the component function runs again
             rerender: () => view.render({}),
             name: `${name}.view`,
             abortOnUnmount: false,
           })
-        // React order: render phase first, then the mount effect
+        // React order: render phase, then the mount effect
         const first = view.render({}).result
         const unmount = view.mount()
         return { first, unmount, render: () => view.render({}).result }
       }
 
-      // visit 1: the profile page straight from SSR — hydration cache hit.
-      // The route's clientLoader does NOT run on hydration (the server loader
-      // already ran), the view just renders.
+      // visit 1: SSR landing — hydration cache hit, no loader on hydration
       const view1 = mountView()
       await wrap(sleep(20))
       expect(view1.render().data).toBe('null:7')
@@ -582,8 +569,7 @@ test('remount after an SSR-hydrated cache hit must render, not throw the cache A
 
       await wrap(sleep(20))
 
-      // visit 2: navigate back — the route's clientLoader awaits the query
-      // BEFORE the new view instance renders
+      // visit 2: navigate back — the route loader awaits the query before render
       await wrap(query()) // ← bug: rejects '<name>.query.withAbort cache [#N]'
 
       const view2 = mountView()

--- a/packages/core/src/extensions/withCache.ts
+++ b/packages/core/src/extensions/withCache.ts
@@ -590,6 +590,7 @@ export let withCache =
             } else {
               if (isPromise(payload)) payload.catch(noop)
               controller.abort('cache')
+              abortVar.set()
             }
 
             cacheVar.set(


### PR DESCRIPTION
## Problem

A computed extended with `withAsyncData() + withCache({ withPersist })` rejects with

```
AbortError: <name>.withAbort cache [#N]
```

when it is **called directly** (`await query()` — exactly what a route loader does) and the call lands on a **persist-hydrated** cache record. Real-world shape: land on a server-rendered page (hydration cache hit), navigate away, navigate back — the route's client loader awaits the query and the whole page falls into the error boundary.

## Mechanism

On a non-SWR cache hit the `withCache` computed middleware runs the body speculatively, then aborts the current call's controller with `'cache'` to cancel that work, and returns the cached result. But `withAbort` (applied by `withAsyncData`) sits **outside** `withCache` in the middleware chain: it sees its own controller aborted and replaces the returned state with a promise **rejected** by that AbortError — even though `withCache` just delivered a perfectly valid cached value.

After persist hydration the very first computation is such a hit, so the query state is *born poisoned*. Render-style reads (`data()`/`pending()`) survive — they are fed by the `cacheVar` hit path and never await the state — but the first direct `await query()` throws. A live-fetched cache record never reproduces this: with unchanged deps a later call doesn't recompute at all, and the state holds the resolved promise of the original fetch.

## Fix

One line: after `controller.abort('cache')`, leave a fresh controller in the frame (`abortVar.set()`). The speculative body work stays cancelled (it subscribed to the old controller), while the call itself stays alive and resolves with the cached value.

## Tests

- `remount after an SSR-hydrated cache hit must render, not throw the cache AbortError` (added on v1001 in 1e95738c) — red before, green with this fix. It also pins that the same flow with a live-fetched cache passes.
- Full core suite: 59 files, 418 passed, 2 expected fail, 2 skipped — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)