### PR TITLE
fix(react): survive StrictMode remount in reatomFactoryComponent

### DIFF
--- a/packages/react/src/reatomComponent.ts
+++ b/packages/react/src/reatomComponent.ts
@@ -1,4 +1,6 @@
 import {
+  _read,
+  abortVar,
   action,
   assert,
   bind,
@@ -6,6 +8,7 @@ import {
   type Frame,
   named,
   notify,
+  type ReatomAbortController,
   reatomAbstractRender,
   ReatomError,
   type Rec,
@@ -170,25 +173,44 @@ export let reatomFactoryComponent = <Props extends Rec = {}>(
   const deps = typeof options === 'object' ? (options.deps ?? []) : []
   const name = typeof options === 'object' ? options.name : options
 
+  type Instance = {
+    controller: ReatomAbortController
+    abort: Fn
+    render: (props: Props) => React.ReactNode
+  }
+
   const Component: Fn = reatomComponent(
     (props: Props) => {
-      const { abort, render } = React.useMemo(
-        () => {
-          const initAction = action(init, `${Component.name}._init`).extend(
-            withAbort(),
-          )
-
-          return {
-            abort: bind(initAction.abort),
-            render: initAction(props, { name: Component.name }),
-          }
-        },
+      const [, recreate] = React.useState(0)
+      const box = React.useMemo(
+        () => ({ instance: null as null | Instance }),
         deps.map((dep) => props[dep]),
       )
 
-      useEffect(() => abort, [])
+      if (!box.instance || box.instance.controller.signal.aborted) {
+        const initAction = action(init, `${Component.name}._init`).extend(
+          withAbort(),
+        )
+        const render = initAction(props, { name: Component.name })
 
-      return render(props)
+        box.instance = {
+          render,
+          controller: abortVar.require(_read(initAction)!),
+          abort: bind(initAction.abort),
+        }
+      }
+
+      const { instance } = box
+
+      useEffect(() => {
+        if (instance.controller.signal.aborted) {
+          recreate((s) => s + 1)
+          return
+        }
+        return () => instance.abort()
+      }, [instance])
+
+      return instance.render(props)
     },
     { deps, name, abortOnUnmount: false },
   )

--- a/packages/react/src/reatomFactoryComponentStrictMode.test.tsx
+++ b/packages/react/src/reatomFactoryComponentStrictMode.test.tsx
@@ -1,0 +1,102 @@
+import type { AtomLike } from '@reatom/core'
+import {
+  atom,
+  clearStack,
+  context,
+  effect,
+  rAF,
+  sleep,
+  take,
+  top,
+  wrap,
+} from '@reatom/core'
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+import { reatomContext, reatomFactoryComponent } from './'
+
+clearStack()
+
+const tick = async () => {
+  await wrap(take(rAF))
+  await wrap(take(rAF))
+}
+
+beforeEach(() => {
+  const root = document.createElement('div')
+  root.id = 'root'
+  document.body.append(root)
+})
+
+afterEach(() => {
+  document.getElementById('root')?.remove()
+})
+
+describe('reatomFactoryComponent effects in StrictMode', () => {
+  const setup = () => {
+    let effectCalls = 0
+
+    const Mirror = reatomFactoryComponent<{ source: AtomLike<number> }>(
+      ({ source }) => {
+        const doubled = atom(source() * 2, 'doubled')
+
+        effect(() => {
+          effectCalls++
+          doubled.set(source() * 2)
+        })
+
+        return () => <div data-testid="doubled">{doubled()}</div>
+      },
+      'Mirror',
+    )
+
+    return {
+      Mirror,
+      getEffectCalls: () => effectCalls,
+      getText: () =>
+        document.querySelector('[data-testid="doubled"]')?.textContent,
+    }
+  }
+
+  const scenario = async (strictMode: boolean) => {
+    const source = atom(1, 'source')
+    const { Mirror, getEffectCalls, getText } = setup()
+
+    const app = (
+      <reatomContext.Provider value={top()}>
+        <Mirror source={source} />
+      </reatomContext.Provider>
+    )
+
+    const root = ReactDOM.createRoot(document.getElementById('root')!)
+    root.render(strictMode ? <React.StrictMode>{app}</React.StrictMode> : app)
+
+    await wrap(tick())
+    expect(getText()).toBe('2')
+
+    const effectCallsAfterMount = getEffectCalls()
+
+    source.set(21)
+    await wrap(sleep())
+    await wrap(tick())
+
+    expect(getEffectCalls()).toBeGreaterThan(effectCallsAfterMount)
+    expect(getText()).toBe('42')
+
+    const effectCallsBeforeUnmount = getEffectCalls()
+    root.unmount()
+    await wrap(tick())
+
+    source.set(100)
+    await wrap(sleep())
+    await wrap(tick())
+    expect(getEffectCalls()).toBe(effectCallsBeforeUnmount)
+  }
+
+  test('control: effect updates the component without StrictMode', () =>
+    context.start(() => scenario(false)))
+
+  test('effect updates the component in StrictMode', () =>
+    context.start(() => scenario(true)))
+})


### PR DESCRIPTION
## Problem

With `<StrictMode>` enabled, a `reatomFactoryComponent` stops updating after its `effect`s fire: the effects visibly run (logs, callbacks), but the committed component never rerenders. Without `StrictMode` everything works. Minimal scenario: a factory creates a local atom that is updated only from an `effect` subscribed to an external atom, and the render function displays the local atom — after the external atom changes, the DOM keeps the initial value forever.

## Root cause

StrictMode's simulated unmount/remount right after the first mount breaks the previous implementation in two ways:

1. **The factory effects get permanently killed.** The `useEffect(() => abort, [])` cleanup runs on the simulated unmount and aborts the init action. Every `effect()` created in the factory is subscribed under that abort controller, and an `effect` short-circuits forever once its controller is aborted. The simulated remount preserves the `useMemo` result, so nothing ever recreates the init — the committed component is left with dead effects.
2. **A second init copy leaks.** StrictMode double-invokes the `useMemo` factory, so the init action runs twice. Only one result is committed; the discarded copy's `abort` is lost, so its effects stay subscribed forever — they keep firing on their own atom copies (which is why the effect appears to work while the component doesn't update), even after a real unmount.

## Fix mechanism

- The `useMemo` now returns a pure box (`{ instance: null }`) that is lazily filled with the init result in the render phase. The box factory has no side effects, so the StrictMode double invocation leaks nothing, and the box object is shared between the two render passes — the init action runs exactly once per instance. The `deps` props keep resetting the box through React's own `useMemo` deps mechanism.
- The instance stores the init's abort controller, taken from the init action frame via `abortVar.require(_read(initAction))`, and is recreated in the render phase whenever the box is empty or the stored controller is already aborted.
- The mount effect is keyed by the instance. If it finds the instance aborted (the StrictMode/`Activity` remount case: the cleanup below has already aborted it), it triggers a rerender, which recreates the instance with fresh effects in the render phase. Otherwise it registers a cleanup that aborts the instance — this runs on the real unmount, keeping the existing `aborts on unmount` semantics.
- Keying the cleanup by instance also aborts the previous init when `deps` change; previously it leaked, since the mount-only cleanup captured just the first init's `abort`.

## Testing

- New browser-mode test (`reatomFactoryComponentStrictMode.test.tsx`): the same scenario with and without `StrictMode`, plus an assertion that no leaked init copy keeps reacting after unmount. The StrictMode test fails without this fix and passes with it.
- Full `@reatom/react` suite passes (38/38), including `aborts on unmount`, deps-change reinit, and the StrictMode input sync tests.
- Verified end-to-end on a Vite + React 19.2 app with a `Transition` factory component: with `StrictMode`, the full `entering → entered → exiting → exited` cycle now renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
