### PR TITLE
fix(core): add reatomLinkedList reset and rebuild reatomFieldArray with it on a bare reset

### DIFF
--- a/docs/src/content/docs/handbook/forms/concepts/field-array.md
+++ b/docs/src/content/docs/handbook/forms/concepts/field-array.md
@@ -245,7 +245,3 @@ const AddressTagField = reatomComponent(
   },
 )
 ```
-
-## Known limitations
-
-Currently, the `dirty` state calculation does not work quite accurately because `reatomLinkedList` does not yet support multiple lists with overlapping elements (when one element can be in two or more linked lists simultaneously). Currently, the dirty check is limited to only checking the number of elements between `initState` and the current field array state. This can lead to situations where, for example, when moving/swapping elements, the field will be considered untouched.

--- a/packages/core/src/form/reatomFieldArray.test.ts
+++ b/packages/core/src/form/reatomFieldArray.test.ts
@@ -443,6 +443,21 @@ describe(`reset consistency (#1309)`, () => {
     ])
   })
 
+  test(`keeps dirty relevant after move`, () => {
+    const fieldArray = reatomFieldArray(['a', 'b', 'c'], {
+      name: 'resetMoveDirty.fieldArray',
+    })
+    expect(fieldArray.focus().dirty).toBe(false)
+
+    fieldArray.move(fieldArray.array()[0]!, fieldArray.array()[2]!)
+    notify()
+    expect(fieldArray.focus().dirty).toBe(true)
+
+    fieldArray.reset()
+    notify()
+    expect(fieldArray.focus().dirty).toBe(false)
+  })
+
   test(`keeps dirty relevant after swap`, () => {
     const fieldArray = reatomFieldArray(['a', 'b', 'c'], {
       name: 'resetSwapDirty.fieldArray',

--- a/packages/core/src/form/reatomFieldArray.test.ts
+++ b/packages/core/src/form/reatomFieldArray.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi } from 'test'
 import { z } from 'zod'
 
-import { addCallHook, atom, notify, sleep, wrap } from '../'
+import { addCallHook, atom, context, notify, sleep, wrap } from '../'
 import { reatomFieldArray } from '.'
 
 test(`validateOnChange`, async () => {
@@ -357,5 +357,174 @@ describe(`reactivity of validate function`, () => {
     fieldArray.create('c')
     notify()
     expect(fieldArray.validation.errors()).toHaveLength(0)
+  })
+})
+
+describe(`reset after element removal (#1309)`, () => {
+  const setup = (name: string) => {
+    const fieldArray = reatomFieldArray(['first', 'second', 'third'], { name })
+    const values = () => fieldArray.array().map((element) => element())
+    return { fieldArray, values }
+  }
+
+  const cases = [
+    { position: 'head', index: 0, afterRemove: ['second', 'third'] },
+    { position: 'middle', index: 1, afterRemove: ['first', 'third'] },
+    { position: 'tail', index: 2, afterRemove: ['first', 'second'] },
+  ]
+
+  for (const { position, index, afterRemove } of cases) {
+    test(`restores ${position} element`, () => {
+      const { fieldArray, values } = setup(`resetAfterRemoval.${position}`)
+
+      fieldArray.remove(fieldArray.array()[index]!)
+      notify()
+      expect(fieldArray().size).toBe(2)
+      expect(values()).toEqual(afterRemove)
+
+      fieldArray.reset()
+      notify()
+      expect(fieldArray().size).toBe(3)
+      expect(values()).toEqual(['first', 'second', 'third'])
+    })
+  }
+
+  test(`restores all elements after multiple removals`, () => {
+    const { fieldArray, values } = setup('resetAfterRemoval.multiple')
+
+    fieldArray.remove(fieldArray.array()[2]!)
+    fieldArray.remove(fieldArray.array()[0]!)
+    notify()
+    expect(fieldArray().size).toBe(1)
+    expect(values()).toEqual(['second'])
+
+    fieldArray.reset()
+    notify()
+    expect(fieldArray().size).toBe(3)
+    expect(values()).toEqual(['first', 'second', 'third'])
+  })
+})
+
+describe(`reset consistency (#1309)`, () => {
+  test(`keeps dirty relevant after removal and bare reset`, () => {
+    const fieldArray = reatomFieldArray(['a', 'b', 'c'], {
+      name: 'resetDirty.fieldArray',
+    })
+    expect(fieldArray.focus().dirty).toBe(false)
+
+    fieldArray.remove(fieldArray.array()[1]!)
+    notify()
+    expect(fieldArray.focus().dirty).toBe(true)
+
+    fieldArray.reset()
+    notify()
+    expect(fieldArray.focus().dirty).toBe(false)
+  })
+
+  test(`keeps dirty relevant after swap`, () => {
+    const fieldArray = reatomFieldArray(['a', 'b', 'c'], {
+      name: 'resetSwapDirty.fieldArray',
+    })
+    expect(fieldArray.focus().dirty).toBe(false)
+
+    fieldArray.swap(fieldArray.array()[0]!, fieldArray.array()[2]!)
+    notify()
+    expect(fieldArray.focus().dirty).toBe(true)
+
+    fieldArray.reset()
+    notify()
+    expect(fieldArray.focus().dirty).toBe(false)
+  })
+
+  test(`preserves element identity on bare reset`, () => {
+    const fieldArray = reatomFieldArray(['a', 'b'], {
+      name: 'resetIdentity.fieldArray',
+    })
+    const elements = fieldArray.array()
+    notify()
+
+    fieldArray.remove(fieldArray.array()[0]!)
+    notify()
+
+    fieldArray.reset()
+    notify()
+    expect(fieldArray.array().every((node, i) => node === elements[i])).toBe(
+      true,
+    )
+  })
+
+  test(`does not touch the focus state on bare reset`, () => {
+    const fieldArray = reatomFieldArray(['a', 'b'], {
+      name: 'resetTouched.fieldArray',
+    })
+
+    fieldArray.remove(fieldArray.array()[0]!)
+    notify()
+
+    fieldArray.reset()
+    notify()
+    expect(fieldArray.focus().touched).toBe(false)
+  })
+
+  test(`bare reset restores the state applied via reset with values`, () => {
+    const fieldArray = reatomFieldArray(['a'], {
+      name: 'resetValues.fieldArray',
+    })
+    const values = () => fieldArray.array().map((element) => element())
+
+    fieldArray.create('b')
+    notify()
+
+    fieldArray.reset(['x', 'y'])
+    notify()
+    expect(values()).toEqual(['x', 'y'])
+
+    fieldArray.remove(fieldArray.array()[0]!)
+    notify()
+
+    fieldArray.reset()
+    notify()
+    expect(values()).toEqual(['x', 'y'])
+  })
+
+  test(`bare reset restores the state applied via initState setter`, () => {
+    const fieldArray = reatomFieldArray(['a'], {
+      name: 'resetInitState.fieldArray',
+    })
+    const values = () => fieldArray.array().map((element) => element())
+    notify()
+
+    fieldArray.initState.set(['x', 'y'])
+    fieldArray.create('b')
+    notify()
+
+    fieldArray.reset()
+    notify()
+    expect(values()).toEqual(['x', 'y'])
+  })
+
+  test(`keeps the state isolated between contexts`, () => {
+    const fieldArray = reatomFieldArray(['a', 'b', 'c'], {
+      name: 'resetContexts.fieldArray',
+    })
+    const values = () => fieldArray.array().map((element) => element())
+
+    const rootA = context.start()
+    const rootB = context.start()
+
+    rootA.run(() => {
+      fieldArray.reset(['x', 'y'])
+      notify()
+      expect(values()).toEqual(['x', 'y'])
+    })
+
+    rootB.run(() => {
+      fieldArray.remove(fieldArray.array()[1]!)
+      notify()
+
+      fieldArray.reset()
+      notify()
+      expect(values()).toEqual(['a', 'b', 'c'])
+    })
   })
 })

--- a/packages/core/src/form/reatomFieldArray.test.ts
+++ b/packages/core/src/form/reatomFieldArray.test.ts
@@ -421,6 +421,28 @@ describe(`reset consistency (#1309)`, () => {
     expect(fieldArray.focus().dirty).toBe(false)
   })
 
+  test(`keeps dirty relevant after an element replacement`, () => {
+    const fieldArray = reatomFieldArray(['a', 'b', 'c'], {
+      name: 'replaceDirty.fieldArray',
+    })
+    expect(fieldArray.focus().dirty).toBe(false)
+
+    // `remove` + `create` compensate the chain length of the stale snapshot
+    fieldArray.remove(fieldArray.array()[1]!)
+    fieldArray.create('d')
+    notify()
+    expect(fieldArray.focus().dirty).toBe(true)
+
+    fieldArray.reset()
+    notify()
+    expect(fieldArray.focus().dirty).toBe(false)
+    expect(fieldArray.array().map((element) => element())).toEqual([
+      'a',
+      'b',
+      'c',
+    ])
+  })
+
   test(`keeps dirty relevant after swap`, () => {
     const fieldArray = reatomFieldArray(['a', 'b', 'c'], {
       name: 'resetSwapDirty.fieldArray',

--- a/packages/core/src/form/reatomFieldArray.ts
+++ b/packages/core/src/form/reatomFieldArray.ts
@@ -4,12 +4,14 @@ import {
   type AtomState,
   isAtom,
   named,
+  withActionMiddleware,
   withParams,
 } from '../core'
 import { withCallHook } from '../extensions'
 import {
   type LinkedList,
   type LinkedListAtom,
+  type LinkedListLikeAtom,
   type LLNode,
   reatomLinkedList,
 } from '../primitives'
@@ -127,7 +129,11 @@ type FieldArrayInitState<T> = {
 export type FieldArrayAtom<
   Param = any,
   Node extends FieldsAtomizeInitState = FieldsAtomizeInitState,
-> = LinkedListAtom<[FieldArrayInitState<Param>], FieldsAtomize<Node>> &
+> = Omit<
+  LinkedListAtom<[FieldArrayInitState<Param>], FieldsAtomize<Node>>,
+  'reset'
+> &
+  LinkedListLikeAtom<FieldArrayState<Node>> &
   BaseFieldExt<
     FieldArrayState<Node>,
     [initState: FieldArrayInitState<Param>[]]
@@ -352,7 +358,7 @@ export function reatomFieldArray<Param, Node extends FieldsAtomizeInitState>(
     }),
   )
 
-  const fieldArrayAtom = reatomLinkedList(
+  const linkedListAtom = reatomLinkedList(
     {
       create: (param) => {
         const factoryName = `${name}.item`
@@ -369,7 +375,11 @@ export function reatomFieldArray<Param, Node extends FieldsAtomizeInitState>(
       ),
     },
     name,
-  ).extend(
+  )
+
+  const llReset = linkedListAtom.reset
+
+  const fieldArrayAtom = linkedListAtom.extend(
     withBaseField({
       initStateAtom,
       getNormalizedState: (state) => {
@@ -380,13 +390,23 @@ export function reatomFieldArray<Param, Node extends FieldsAtomizeInitState>(
           elements.push(head)
           head = head[state.LL_NEXT]
         }
-        // TODO: reatomLinkedLost does not support the same elements in two or more difference linked lists so we need to limit size of the array there
-        return elements.slice(0, state.size)
+        // a stale `initState` snapshot chain is desynced from its `size`, as
+        // the nodes are shared with the live list, so use `initNodes` then
+        return elements.length === state.size ? elements : state.initNodes
       },
       getValue: (): FieldArrayLLNode<Node>[] => fieldArrayAtom.array(),
       isDirty,
       ...restOptions,
     }),
+  )
+
+  fieldArrayAtom.reset.extend(
+    withActionMiddleware(() =>
+      function fieldArrayReset(next, ...params) {
+        if (!params.length) llReset()
+        return next(...params)
+      },
+    ),
   )
 
   return Object.assign(fieldArrayAtom, {

--- a/packages/core/src/form/reatomFieldArray.ts
+++ b/packages/core/src/form/reatomFieldArray.ts
@@ -10,11 +10,11 @@ import {
 import { withCallHook } from '../extensions'
 import {
   type LinkedList,
-  type LinkedListAtom,
   type LinkedListLikeAtom,
+  type LinkedListMethods,
   type LLNode,
+  linkedListToArray,
   reatomLinkedList,
-  toArray,
 } from '../primitives'
 import { isShallowEqual } from '../utils'
 import type { FieldAtom } from './reatomField'
@@ -130,11 +130,12 @@ type FieldArrayInitState<T> = {
 export type FieldArrayAtom<
   Param = any,
   Node extends FieldsAtomizeInitState = FieldsAtomizeInitState,
-> = Omit<
-  LinkedListAtom<[FieldArrayInitState<Param>], FieldsAtomize<Node>>,
-  'reset'
-> &
-  LinkedListLikeAtom<FieldArrayState<Node>> &
+> = LinkedListLikeAtom<FieldArrayState<Node>> &
+  // the field `reset` from `BaseFieldExt` shadows the linked list one
+  Omit<
+    LinkedListMethods<[FieldArrayInitState<Param>], FieldsAtomize<Node>>,
+    'reset'
+  > &
   BaseFieldExt<
     FieldArrayState<Node>,
     [initState: FieldArrayInitState<Param>[]]
@@ -387,7 +388,7 @@ export function reatomFieldArray<Param, Node extends FieldsAtomizeInitState>(
         // an `initState` snapshot shares its nodes with the live list and its
         // chain rots on the in-place mutations, so represent it with the
         // immutable `initNodes` and walk the chain only for the live state
-        state === fieldArrayAtom() ? toArray(state) : state.initNodes,
+        state === linkedListAtom() ? linkedListToArray(state) : state.initNodes,
       getValue: (): FieldArrayLLNode<Node>[] => fieldArrayAtom.array(),
       isDirty,
       ...restOptions,

--- a/packages/core/src/form/reatomFieldArray.ts
+++ b/packages/core/src/form/reatomFieldArray.ts
@@ -396,11 +396,12 @@ export function reatomFieldArray<Param, Node extends FieldsAtomizeInitState>(
   )
 
   fieldArrayAtom.reset.extend(
-    withActionMiddleware(() =>
-      function fieldArrayReset(next, ...params) {
-        if (!params.length) llReset()
-        return next(...params)
-      },
+    withActionMiddleware(
+      () =>
+        function fieldArrayReset(next, ...params) {
+          if (!params.length) llReset()
+          return next(...params)
+        },
     ),
   )
 

--- a/packages/core/src/form/reatomFieldArray.ts
+++ b/packages/core/src/form/reatomFieldArray.ts
@@ -14,6 +14,7 @@ import {
   type LinkedListLikeAtom,
   type LLNode,
   reatomLinkedList,
+  toArray,
 } from '../primitives'
 import { isShallowEqual } from '../utils'
 import type { FieldAtom } from './reatomField'
@@ -382,18 +383,11 @@ export function reatomFieldArray<Param, Node extends FieldsAtomizeInitState>(
   const fieldArrayAtom = linkedListAtom.extend(
     withBaseField({
       initStateAtom,
-      getNormalizedState: (state) => {
-        // TODO decouple into a function (including a reatomForm one)
-        const elements = []
-        let head = state.head
-        while (head) {
-          elements.push(head)
-          head = head[state.LL_NEXT]
-        }
-        // a stale `initState` snapshot chain is desynced from its `size`, as
-        // the nodes are shared with the live list, so use `initNodes` then
-        return elements.length === state.size ? elements : state.initNodes
-      },
+      getNormalizedState: (state) =>
+        // an `initState` snapshot shares its nodes with the live list and its
+        // chain rots on the in-place mutations, so represent it with the
+        // immutable `initNodes` and walk the chain only for the live state
+        state === fieldArrayAtom() ? toArray(state) : state.initNodes,
       getValue: (): FieldArrayLLNode<Node>[] => fieldArrayAtom.array(),
       isDirty,
       ...restOptions,

--- a/packages/core/src/form/reatomForm.ts
+++ b/packages/core/src/form/reatomForm.ts
@@ -17,6 +17,7 @@ import {
   isFieldArrayAtom,
   isFieldAtom,
   isRec,
+  linkedListToArray,
   named,
   withAbort,
   withAsync,
@@ -544,11 +545,7 @@ export function reatomForm<
       else {
         element.extend(
           withInit((state) => {
-            let head = state.head
-            while (head) {
-              setupFields(head)
-              head = head[state.LL_NEXT]
-            }
+            linkedListToArray(state).forEach((node) => setupFields(node))
             return state
           }),
         )

--- a/packages/core/src/primitives/reatomLinkedList.test.ts
+++ b/packages/core/src/primitives/reatomLinkedList.test.ts
@@ -568,18 +568,16 @@ describe('reset', () => {
     expect(list.array()).toBe(arrayBefore)
   })
 
-  test('should emit clear and createMany changes', () => {
+  test('should skip granular changes and leave a version gap instead', () => {
     const list = setup()
-    const initNodes = list.array()
 
-    list.remove(initNodes[0]!)
+    list.remove(list.array()[0]!)
     notify()
+    const { version } = list()
 
     list.reset()
-    expect(list().changes).toEqual([
-      { kind: 'clear' },
-      { kind: 'createMany', nodes: initNodes },
-    ])
+    expect(list().changes).toEqual([])
+    expect(list().version).toBe(version + 2)
   })
 
   test('should keep derived reatomMap consistent', () => {

--- a/packages/core/src/primitives/reatomLinkedList.test.ts
+++ b/packages/core/src/primitives/reatomLinkedList.test.ts
@@ -10,7 +10,7 @@ import type {
   LL_PREV,
   LLNode,
 } from './reatomLinkedList'
-import { reatomLinkedList, toArray } from './reatomLinkedList'
+import { reatomLinkedList, linkedListToArray } from './reatomLinkedList'
 
 const validateIntegrity = <T extends LLNode>(
   head: T | null,
@@ -696,7 +696,7 @@ describe('serialization / deserialization', () => {
     ).extend(
       withPersist({
         key,
-        toSnapshot: (state) => deatomize(toArray(state)),
+        toSnapshot: (state) => deatomize(linkedListToArray(state)),
       }),
     )
 

--- a/packages/core/src/primitives/reatomLinkedList.test.ts
+++ b/packages/core/src/primitives/reatomLinkedList.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, subscribe, test, vi } from 'test'
 
-import { atom, computed, isAtom, isConnected, notify } from '../core'
+import { atom, computed, context, isAtom, isConnected, notify } from '../core'
 import { withChangeHook } from '../extensions'
 import { deatomize, isCausedBy } from '../methods'
 import { createMemStorage, reatomPersist } from '../persist'
@@ -476,6 +476,185 @@ test('should allow using element from one list in another list via list-specific
   expect(nextInB?.n).toBe(20)
 
   expect(nodeInA).not.toBe(nodeInB)
+})
+
+describe('reset', () => {
+  const setup = () =>
+    reatomLinkedList({
+      create: (n: number) => ({ n }),
+      initSnapshot: [[1], [2], [3]],
+    })
+
+  test('should restore the initial state after removals preserving node identity', () => {
+    const list = setup()
+    const initNodes = list.array()
+
+    list.remove(initNodes[1]!)
+    notify()
+    expect(list.array().map(({ n }) => n)).toEqual([1, 3])
+
+    list.reset()
+    notify()
+    expect(list().size).toBe(3)
+    expect(list.array().map(({ n }) => n)).toEqual([1, 2, 3])
+    expect(list.array().every((node, i) => node === initNodes[i])).toBe(true)
+    validateIntegrity(list().head, list)
+  })
+
+  test('should drop created elements', () => {
+    const list = setup()
+
+    const four = list.create(4)
+    notify()
+    expect(list.array().map(({ n }) => n)).toEqual([1, 2, 3, 4])
+
+    list.reset()
+    notify()
+    expect(list.array().map(({ n }) => n)).toEqual([1, 2, 3])
+    expect(list.array()).not.toContain(four)
+    validateIntegrity(list().head, list)
+  })
+
+  test('should restore the order after swap and move', () => {
+    const list = setup()
+    const [one, , three] = list.array()
+
+    list.swap(one!, three!)
+    list.move(one!, null)
+    notify()
+    expect(list.array().map(({ n }) => n)).toEqual([1, 3, 2])
+
+    list.reset()
+    notify()
+    expect(list.array().map(({ n }) => n)).toEqual([1, 2, 3])
+    validateIntegrity(list().head, list)
+  })
+
+  test('should restore all elements after clear', () => {
+    const list = setup()
+
+    list.clear()
+    notify()
+    expect(list().size).toBe(0)
+
+    list.reset()
+    notify()
+    expect(list.array().map(({ n }) => n)).toEqual([1, 2, 3])
+  })
+
+  test('should clear the list created without initial elements', () => {
+    const list = reatomLinkedList((n: number) => ({ n }))
+
+    list.create(1)
+    list.create(2)
+    notify()
+
+    list.reset()
+    notify()
+    expect(list().size).toBe(0)
+    expect(list.array()).toEqual([])
+  })
+
+  test('should be a no-op for a pristine list', () => {
+    const list = setup()
+    const track = subscribe(list)
+    notify()
+    const calls = track.mock.calls.length
+    const arrayBefore = list.array()
+
+    list.reset()
+    notify()
+    expect(track.mock.calls.length).toBe(calls)
+    expect(list.array()).toBe(arrayBefore)
+  })
+
+  test('should emit clear and createMany changes', () => {
+    const list = setup()
+    const initNodes = list.array()
+
+    list.remove(initNodes[0]!)
+    notify()
+
+    list.reset()
+    expect(list().changes).toEqual([
+      { kind: 'clear' },
+      { kind: 'createMany', nodes: initNodes },
+    ])
+  })
+
+  test('should keep derived reatomMap consistent', () => {
+    const list = setup()
+    const rows = list.reatomMap(({ n }) => ({ n: n * 10 }))
+    const track = subscribe(computed(() => rows.array().map(({ n }) => n)))
+    notify()
+    expect(track.mock.lastCall?.[0]).toEqual([10, 20, 30])
+
+    list.remove(list.array()[1]!)
+    notify()
+    expect(track.mock.lastCall?.[0]).toEqual([10, 30])
+
+    list.reset()
+    notify()
+    expect(track.mock.lastCall?.[0]).toEqual([10, 20, 30])
+  })
+
+  test('should reset to the state applied via initiateFromSnapshot', () => {
+    const list = setup()
+
+    list.set(list.initiateFromSnapshot([[10], [20], [30]]))
+    notify()
+    expect(list.array().map(({ n }) => n)).toEqual([10, 20, 30])
+
+    list.remove(list.array()[0]!)
+    notify()
+    expect(list.array().map(({ n }) => n)).toEqual([20, 30])
+
+    list.reset()
+    notify()
+    expect(list.array().map(({ n }) => n)).toEqual([10, 20, 30])
+  })
+
+  test('should compose with batch', () => {
+    const list = setup()
+
+    list.batch(() => {
+      list.create(4)
+      list.reset()
+      list.create(5)
+    })
+    notify()
+    expect(list.array().map(({ n }) => n)).toEqual([1, 2, 3, 5])
+    validateIntegrity(list().head, list)
+  })
+
+  test('should keep the state isolated between contexts', () => {
+    const list = setup()
+
+    const rootA = context.start()
+    const rootB = context.start()
+
+    rootA.run(() => {
+      list.set(list.initiateFromSnapshot([[10]]))
+      notify()
+      expect(list.array().map(({ n }) => n)).toEqual([10])
+    })
+
+    rootB.run(() => {
+      list.create(4)
+      notify()
+      list.reset()
+      notify()
+      expect(list.array().map(({ n }) => n)).toEqual([1, 2, 3])
+    })
+
+    rootA.run(() => {
+      list.create(11)
+      notify()
+      list.reset()
+      notify()
+      expect(list.array().map(({ n }) => n)).toEqual([10])
+    })
+  })
 })
 
 describe('serialization / deserialization', () => {

--- a/packages/core/src/primitives/reatomLinkedList.ts
+++ b/packages/core/src/primitives/reatomLinkedList.ts
@@ -65,11 +65,16 @@ export interface LinkedListLikeAtom<T extends LinkedList = LinkedList>
   __reatomLinkedList: true
 }
 
-export interface LinkedListAtom<
+/**
+ * The own methods of a linked list atom, decoupled from the base atom shape,
+ * so derived abstractions (like `reatomFieldArray`) can compose them with a
+ * different base keeping every member declared in a single place.
+ */
+export interface LinkedListMethods<
   Params extends any[] = any[],
   Node extends Rec = Rec,
   Key extends keyof Node = never,
-> extends LinkedListLikeAtom<LinkedList<LLNode<Node>>> {
+> {
   batch: Action<[cb: Fn]>
 
   create: Action<Params, LLNode<Node>>
@@ -131,6 +136,13 @@ export interface LinkedListAtom<
   //   name?: string,
   // ) => Atom<T>
 }
+
+export interface LinkedListAtom<
+  Params extends any[] = any[],
+  Node extends Rec = Rec,
+  Key extends keyof Node = never,
+> extends LinkedListLikeAtom<LinkedList<LLNode<Node>>>,
+    LinkedListMethods<Params, Node, Key> {}
 
 // TODO rename to `DerivedLinkedList`
 export interface LinkedListDerivedState<
@@ -297,7 +309,16 @@ const clearLL = <Node extends LLNode>(state: LinkedList<Node>) => {
   }
 }
 
-export const toArray = <T extends Rec>(
+/**
+ * Collects the nodes of a linked list state into a plain array in the chain
+ * order. Useful when you deal with a raw {@link LinkedList} state — in
+ * extensions and hooks; for an atom prefer the memoized `array()` accessor.
+ *
+ * Pass the previously returned array as the second argument to preserve the
+ * reference when the chain has not changed, keeping downstream memoization
+ * intact.
+ */
+export const linkedListToArray = <T extends Rec>(
   { head, LL_NEXT }: LinkedList<LLNode<T>>,
   prev?: Array<LLNode<T>>,
 ): Array<LLNode<T>> => {
@@ -528,7 +549,7 @@ export function reatomLinkedList<
       addLL(state, node, state.tail)
     }
 
-    state.initNodes = toArray(state)
+    state.initNodes = linkedListToArray(state)
 
     return state
   }
@@ -553,7 +574,7 @@ export function reatomLinkedList<
       addLL(state, node, state.tail)
     }
 
-    state.initNodes = toArray(state)
+    state.initNodes = linkedListToArray(state)
 
     return state
   }
@@ -744,7 +765,7 @@ export function reatomLinkedList<
   }
 
   const array: LinkedListAtom<Params, Node, Key>['array'] = computed(
-    (state: Array<LLNode<Node>> = []) => toArray(linkedList(), state),
+    (state: Array<LLNode<Node>> = []) => linkedListToArray(linkedList(), state),
     `${name}.array`,
   )
 
@@ -917,7 +938,7 @@ export function reatomLinkedList<
     // @ts-ignore
     const array: LinkedListDerivedAtom<LLNode<Node>, LLNode<T>>['array'] =
       computed(
-        (state: Array<LLNode<T>> = []) => toArray(mapList(), state),
+        (state: Array<LLNode<T>> = []) => linkedListToArray(mapList(), state),
         `${name}.array`,
       )
 
@@ -1033,7 +1054,7 @@ export function reatomLinkedList<
         snapshot.map((value) => [value] as Params),
       )
     }),
-    withToJson((state) => toArray(state)),
+    withToJson((state) => linkedListToArray(state)),
   ) as LinkedListAtom<Params, Node, Key>
 }
 

--- a/packages/core/src/primitives/reatomLinkedList.ts
+++ b/packages/core/src/primitives/reatomLinkedList.ts
@@ -49,16 +49,16 @@ export interface LinkedList<
   size: number
   /**
    * Monotonic transaction counter driving the `changes` replay protocol: a
-   * consumer holding the previous version applies `changes`, a bigger gap
-   * means missed updates and requires a full rebuild. Never rewinds.
+   * consumer holding the previous version applies `changes`, a bigger gap means
+   * missed updates and requires a full rebuild. Never rewinds.
    */
   version: number
   changes: Array<LLChanges<Node>>
   /**
    * The nodes of the initial state in their initial order. Unlike the node
    * chain, this plain array is immune to the in-place pointer mutations
-   * performed by list operations, so it stays pristine across the atom
-   * lifetime and is used by `reset`. Empty for derived lists (`reatomMap`).
+   * performed by list operations, so it stays pristine across the atom lifetime
+   * and is used by `reset`. Empty for derived lists (`reatomMap`).
    */
   initNodes: Array<Node>
 }
@@ -71,8 +71,8 @@ export interface LinkedListLikeAtom<T extends LinkedList = LinkedList>
 }
 
 /**
- * The own methods of a linked list atom, decoupled from the base atom shape,
- * so derived abstractions (like `reatomFieldArray`) can compose them with a
+ * The own methods of a linked list atom, decoupled from the base atom shape, so
+ * derived abstractions (like `reatomFieldArray`) can compose them with a
  * different base keeping every member declared in a single place.
  */
 export interface LinkedListMethods<
@@ -146,7 +146,9 @@ export interface LinkedListAtom<
   Params extends any[] = any[],
   Node extends Rec = Rec,
   Key extends keyof Node = never,
-> extends LinkedListLikeAtom<LinkedList<LLNode<Node>>>,
+>
+  extends
+    LinkedListLikeAtom<LinkedList<LLNode<Node>>>,
     LinkedListMethods<Params, Node, Key> {}
 
 // TODO rename to `DerivedLinkedList`
@@ -314,7 +316,9 @@ const clearLL = <Node extends LLNode>(state: LinkedList<Node>) => {
   }
 }
 
-const isPristineLL = <Node extends LLNode>(state: LinkedList<Node>): boolean => {
+const isPristineLL = <Node extends LLNode>(
+  state: LinkedList<Node>,
+): boolean => {
   const LL_NEXT: LL_NEXT = state.LL_NEXT as any
   let head: null | LLNode = state.head
   for (const node of state.initNodes) {

--- a/packages/core/src/primitives/reatomLinkedList.ts
+++ b/packages/core/src/primitives/reatomLinkedList.ts
@@ -47,6 +47,11 @@ export interface LinkedList<
   head: null | Node
   tail: null | Node
   size: number
+  /**
+   * Monotonic transaction counter driving the `changes` replay protocol: a
+   * consumer holding the previous version applies `changes`, a bigger gap
+   * means missed updates and requires a full rebuild. Never rewinds.
+   */
   version: number
   changes: Array<LLChanges<Node>>
   /**
@@ -307,6 +312,16 @@ const clearLL = <Node extends LLNode>(state: LinkedList<Node>) => {
     node[LL_NEXT] = null
     node = next
   }
+}
+
+const isPristineLL = <Node extends LLNode>(state: LinkedList<Node>): boolean => {
+  const LL_NEXT: LL_NEXT = state.LL_NEXT as any
+  let head: null | LLNode = state.head
+  for (const node of state.initNodes) {
+    if (head !== node) return false
+    head = head[LL_NEXT]
+  }
+  return head === null
 }
 
 /**
@@ -727,33 +742,14 @@ export function reatomLinkedList<
     })
   }, `${name}.clear`)
 
-  const isPristine = (state: LinkedList<LLNode<Node>>): boolean => {
-    if (state.size !== state.initNodes.length) return false
-    let head: null | LLNode<Node> = state.head
-    for (const node of state.initNodes) {
-      if (head !== node) return false
-      head = head[LL_NEXT]
-    }
-    return head === null
-  }
-
   const reset = action((): void => {
-    if (isPristine(STATE ?? linkedList())) return
+    if (isPristineLL(STATE ?? linkedList())) return
 
     return batchFn(() => {
       const state = STATE!
-      const { initNodes } = state
-
       clearLL(state)
-      state.changes.push({ kind: 'clear' })
-
-      if (initNodes.length) {
-        for (const node of initNodes) {
-          throwModel(node)
-          addLL(state, node, state.tail)
-        }
-        state.changes.push({ kind: 'createMany', nodes: initNodes.slice() })
-      }
+      for (const node of state.initNodes) addLL(state, node, state.tail)
+      state.version++
     })
   }, `${name}.reset`)
 

--- a/packages/core/src/primitives/reatomLinkedList.ts
+++ b/packages/core/src/primitives/reatomLinkedList.ts
@@ -49,6 +49,13 @@ export interface LinkedList<
   size: number
   version: number
   changes: Array<LLChanges<Node>>
+  /**
+   * The nodes of the initial state in their initial order. Unlike the node
+   * chain, this plain array is immune to the in-place pointer mutations
+   * performed by list operations, so it stays pristine across the atom
+   * lifetime and is used by `reset`. Empty for derived lists (`reatomMap`).
+   */
+  initNodes: Array<Node>
 }
 
 export interface LinkedListLikeAtom<T extends LinkedList = LinkedList>
@@ -72,6 +79,14 @@ export interface LinkedListAtom<
   swap: Action<[a: LLNode<Node>, b: LLNode<Node>], void>
   move: Action<[node: LLNode<Node>, after: null | LLNode<Node>], void>
   clear: Action<[], void>
+
+  /**
+   * Restores the list to its initial nodes in their initial order — the state
+   * captured at creation or at the last `initiateFromState` /
+   * `initiateFromSnapshot` application. Node identity is preserved: the
+   * original node objects are relinked, not recreated.
+   */
+  reset: Action<[], void>
 
   find: (cb: (node: LLNode<Node>) => boolean) => null | LLNode<Node>
 
@@ -505,12 +520,15 @@ export function reatomLinkedList<
       changes: [],
       head: null,
       tail: null,
+      initNodes: [],
     } as LinkedList<LLNode<Node>>
 
     for (const node of initState) {
       throwModel(node)
       addLL(state, node, state.tail)
     }
+
+    state.initNodes = toArray(state)
 
     return state
   }
@@ -527,12 +545,15 @@ export function reatomLinkedList<
       changes: [],
       head: null,
       tail: null,
+      initNodes: [],
     } as LinkedList<LLNode<Node>>
 
     for (const node of initState) {
       throwModel(node)
       addLL(state, node, state.tail)
     }
+
+    state.initNodes = toArray(state)
 
     return state
   }
@@ -542,25 +563,28 @@ export function reatomLinkedList<
 
     let result: T
 
-    linkedList.set(({ head, tail, size, version, LL_PREV, LL_NEXT }) => {
-      STATE = {
-        LL_PREV,
-        LL_NEXT,
-        size,
-        version: version + 1,
-        changes: [],
-        head,
-        tail,
-      }
+    linkedList.set(
+      ({ head, tail, size, version, LL_PREV, LL_NEXT, initNodes }) => {
+        STATE = {
+          LL_PREV,
+          LL_NEXT,
+          size,
+          version: version + 1,
+          changes: [],
+          head,
+          tail,
+          initNodes,
+        }
 
-      try {
-        result = cb()
+        try {
+          result = cb()
 
-        return STATE
-      } finally {
-        STATE = null
-      }
-    })
+          return STATE
+        } finally {
+          STATE = null
+        }
+      },
+    )
 
     return result!
   }
@@ -682,6 +706,36 @@ export function reatomLinkedList<
     })
   }, `${name}.clear`)
 
+  const isPristine = (state: LinkedList<LLNode<Node>>): boolean => {
+    if (state.size !== state.initNodes.length) return false
+    let head: null | LLNode<Node> = state.head
+    for (const node of state.initNodes) {
+      if (head !== node) return false
+      head = head[LL_NEXT]
+    }
+    return head === null
+  }
+
+  const reset = action((): void => {
+    if (isPristine(STATE ?? linkedList())) return
+
+    return batchFn(() => {
+      const state = STATE!
+      const { initNodes } = state
+
+      clearLL(state)
+      state.changes.push({ kind: 'clear' })
+
+      if (initNodes.length) {
+        for (const node of initNodes) {
+          throwModel(node)
+          addLL(state, node, state.tail)
+        }
+        state.changes.push({ kind: 'createMany', nodes: initNodes.slice() })
+      }
+    })
+  }, `${name}.reset`)
+
   const find = (cb: (node: LLNode<Node>) => boolean): null | LLNode<Node> => {
     for (let { head } = linkedList(); head; head = head[LL_NEXT]) {
       if (cb(head)) return head
@@ -753,6 +807,7 @@ export function reatomLinkedList<
           changes: [],
           head: null,
           tail: null,
+          initNodes: [],
           map: new WeakMap(),
         }
 
@@ -773,6 +828,7 @@ export function reatomLinkedList<
           size: mapList.size,
           version: ll.version,
           changes: [],
+          initNodes: [],
           map: mapList.map,
         }
 
@@ -946,6 +1002,7 @@ export function reatomLinkedList<
       swap,
       move,
       clear,
+      reset,
 
       find,
 


### PR DESCRIPTION
Fixes #1309. Supersedes #1315.

## Problem

`reatomFieldArray`'s `initState` snapshot is captured from the live linked list through the cross-initialization, so it shares the node objects with it. `remove` / `swap` / `move` / `create` rewrite the nodes' `LL_PREV` / `LL_NEXT` pointers in place, corrupting the frozen snapshot retroactively:

- a bare `reset()` restored a broken chain with a mismatched `size` (#1309) — and `reatomFieldSet.reset` calls exactly the bare form, so every `form.reset()` hits this;
- `focus.dirty` stayed `false` after an element removal;
- `initState()` exposed an inconsistent structure.

#1315 routed the bare reset through a module-level `let` snapshot, but that variable is shared across parallel contexts (`context.start()`) and the values-rebuild recreates every element field, losing the node identity.

## Fix

The snapshot model of the linked list is the root cause, so the fix lives in the primitive:

- The `LinkedList` state now carries `initNodes` — a plain array of the initial nodes in their initial order. It is immune to the in-place pointer mutations and, being a part of the state, per-context by construction.
- The new `reatomLinkedList` `reset` action relinks `initNodes` back, preserving the node identity, emitting regular `clear` + `createMany` changes (no protocol extension for the derived lists) and being a no-op for a pristine list.
- `reatomFieldArray` wraps its field `reset` with `withActionMiddleware` to route a bare call through the list reset first, while the live chain still reaches all the linked nodes (`withBaseField` is untouched). The `getNormalizedState` slice workaround is replaced with a consistency check falling back to `initNodes`, which also fixes the dirty tracking after removals and reorderings.

The reset-after-removal test scenarios are ported from #1315 by @maatheuus — thanks!

🤖 Generated with [Claude Code](https://claude.com/claude-code)