### PR TITLE
fix(core): isolate incompatible runtimes

### DIFF
--- a/packages/core/.size-limit.json
+++ b/packages/core/.size-limit.json
@@ -3,7 +3,7 @@
     "name": "raw atom",
     "path": "dist/index.js",
     "import": "{ atom }",
-    "limit": "3.3 KB"
+    "limit": "3.4 KB"
   },
   {
     "name": "main framework",

--- a/packages/core/bench/README.md
+++ b/packages/core/bench/README.md
@@ -19,7 +19,7 @@ Env filters shared by the A/B harnesses:
 
 - `LIB=core|next` — which sources to load (`core` = `../src`, `next` =
   `../../next/src`). Default `core`. Variants must run in **separate
-  processes** — they share `globalThis.__REATOM`.
+  processes** — copies with the same `VERSION` share one global runtime.
 - `SCENARIO=<substr>` — keep only matching scenario names.
 - `BATCHES=<n>` — `bench_compare` batch count (default 30).
 - `COUNTS=2048,512` — `bench_dynamic_ab` list sizes.

--- a/packages/core/src/core/atom.ts
+++ b/packages/core/src/core/atom.ts
@@ -3,7 +3,7 @@ import type { ReatomAbortController } from '../methods'
 import { type Fn, isAbort, type Rec, type Unsubscribe } from '../utils'
 import type { Action, ActionState, Ext } from './'
 import { _enqueue, type Extend, extend, isAction, notify } from './'
-import { _createGlobal, ensureReatomGlobal, VERSION } from './globalStore'
+import { _createGlobal, ensureReatomGlobal } from './globalStore'
 
 /*
 Atom call flow:
@@ -409,12 +409,6 @@ export interface ContextAtom extends AtomLike<RootState, [], RootFrame> {
 export class ReatomError extends Error {}
 
 let reatomRuntime = ensureReatomGlobal()
-
-if (reatomRuntime.version !== VERSION) {
-  throw new ReatomError(
-    `can't use different versions of the library. Loaded: ${reatomRuntime.version}, duplicated: ${VERSION}`,
-  )
-}
 
 export let EXTENSIONS = reatomRuntime.extensions as Array<Ext>
 
@@ -1555,4 +1549,4 @@ export let mock = <Params extends any[], Payload>(
   }
 }
 
-STACK.push(context.start())
+if (context.count === 0) STACK.push(context.start())

--- a/packages/core/src/core/globalStore.ts
+++ b/packages/core/src/core/globalStore.ts
@@ -5,32 +5,60 @@ export type ReatomGlobal = {
   extensions: unknown[]
 } & Record<string, unknown>
 
-declare global {
-  var __REATOM: ReatomGlobal | undefined
+let runtimeKey: symbol | undefined
+let currentRuntime: ReatomGlobal | undefined
+
+let createRuntime = (key?: symbol): ReatomGlobal => {
+  let runtime: ReatomGlobal = { version: VERSION, extensions: [] }
+  if (key) Object.defineProperty(runtime, key, { value: runtime })
+  return runtime
 }
 
 /* @__NO_SIDE_EFFECTS__ */
 export function ensureReatomGlobal(): ReatomGlobal {
-  let rt = globalThis.__REATOM as undefined | unknown[] | ReatomGlobal
+  if (currentRuntime) return currentRuntime
 
-  if (rt === undefined) {
-    rt = { version: VERSION, extensions: [] }
-    globalThis.__REATOM = rt
-    return rt
+  try {
+    let key = (runtimeKey ??= Symbol.for(`@reatom/${VERSION}`))
+    let carrier = Object.getOwnPropertyDescriptor(globalThis, key)
+    currentRuntime = carrier?.value
+    if (
+      !currentRuntime ||
+      carrier?.configurable ||
+      carrier.writable ||
+      Object.getOwnPropertyDescriptor(currentRuntime, key)?.value !==
+        currentRuntime ||
+      currentRuntime.version !== VERSION ||
+      !Array.isArray(currentRuntime.extensions) ||
+      !Object.isExtensible(currentRuntime) ||
+      !Object.isExtensible(currentRuntime.extensions)
+    ) {
+      currentRuntime = createRuntime(key)
+      Object.defineProperty(globalThis, key, {
+        configurable: false,
+        enumerable: false,
+        value: currentRuntime,
+        writable: false,
+      })
+    }
+  } catch {
+    currentRuntime = createRuntime()
   }
 
-  if (Array.isArray(rt)) {
-    let extensions = rt
-    rt = { version: VERSION, extensions }
-    globalThis.__REATOM = rt
-    return rt
-  }
-
-  return rt as ReatomGlobal
+  return currentRuntime
 }
 
 /* @__NO_SIDE_EFFECTS__ */
 export function _createGlobal<T>(name: string, init: () => T): T {
   let g = ensureReatomGlobal()
-  return (g[name] ??= init()) as T
+  if (Object.hasOwn(g, name)) return (g[name] ??= init()) as T
+
+  let value = init()
+  Object.defineProperty(g, name, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  })
+  return value
 }

--- a/packages/core/src/core/runtime-isolation.test.ts
+++ b/packages/core/src/core/runtime-isolation.test.ts
@@ -1,0 +1,259 @@
+import { spawnSync } from 'node:child_process'
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { execPath } from 'node:process'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import { afterAll, afterEach, beforeAll, expect, test } from 'test'
+import { build } from 'tsdown'
+
+import { VERSION } from './globalStore'
+
+type Format = 'cjs' | 'esm'
+type RuntimeFixture = {
+  format: Format
+  path: string
+  url: string
+}
+
+const childTimeout = 15_000
+const testTimeout = 20_000
+const buildTimeout = 60_000
+const coreRoot = fileURLToPath(new URL('../../', import.meta.url))
+const tempDirs = new Set<string>()
+let fixtureDir = ''
+let esmBundle = ''
+let cjsBundle = ''
+
+beforeAll(async () => {
+  fixtureDir = mkdtempSync(join(tmpdir(), 'reatom-runtime-isolation-build-'))
+
+  try {
+    await build({
+      clean: true,
+      cwd: coreRoot,
+      deps: { neverBundle: ['idb-keyval'] },
+      dts: false,
+      entry: join(coreRoot, 'src/index.ts'),
+      fixedExtension: false,
+      format: {
+        cjs: { target: ['node18'] },
+        esm: { target: ['es2024'] },
+      },
+      logLevel: 'silent',
+      outDir: fixtureDir,
+      report: false,
+      sourcemap: false,
+    })
+  } catch (error) {
+    rmSync(fixtureDir, { force: true, recursive: true })
+    throw new Error('runtime isolation fixture build failed', { cause: error })
+  }
+
+  esmBundle = join(fixtureDir, 'index.js')
+  cjsBundle = join(fixtureDir, 'index.cjs')
+  for (const bundle of [esmBundle, cjsBundle]) {
+    if (!existsSync(bundle)) {
+      throw new Error(`runtime isolation fixture is missing: ${bundle}`)
+    }
+  }
+}, buildTimeout)
+
+afterAll(() => {
+  if (fixtureDir) rmSync(fixtureDir, { force: true, recursive: true })
+})
+
+afterEach(() => {
+  for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true })
+  tempDirs.clear()
+})
+
+function copyRuntime(
+  format: Format,
+  name: string,
+  version = VERSION,
+): RuntimeFixture {
+  const source = format === 'esm' ? esmBundle : cjsBundle
+  const bundle = readFileSync(source, 'utf8')
+
+  if (version === VERSION) {
+    return writeFixture(format, name, bundle)
+  } else {
+    const marker = JSON.stringify(VERSION)
+    const markerCount = bundle.split(marker).length - 1
+    expect(markerCount, 'runtime VERSION marker was not found').toBeGreaterThan(
+      0,
+    )
+    const mutated = bundle.replaceAll(marker, JSON.stringify(version))
+    expect(mutated.includes(marker), 'runtime VERSION marker remains').toBe(
+      false,
+    )
+    return writeFixture(format, name, mutated)
+  }
+}
+
+function writeFixture(format: Format, name: string, source: string) {
+  const dir = mkdtempSync(join(tmpdir(), 'reatom-runtime-isolation-'))
+  tempDirs.add(dir)
+  const path = join(dir, `${name}.${format === 'esm' ? 'mjs' : 'cjs'}`)
+  writeFileSync(path, source)
+  return { format, path, url: pathToFileURL(path).href }
+}
+
+function loadRuntime(name: string, fixture: RuntimeFixture) {
+  return fixture.format === 'esm'
+    ? `const ${name} = await import(${JSON.stringify(fixture.url)})`
+    : `const ${name} = require(${JSON.stringify(fixture.path)})`
+}
+
+function smokeRuntime(runtime: string, name: string, value: number) {
+  return `const ${name} = ${runtime}.atom(0, '${name}'); ${name}.set(${value}); if (${name}() !== ${value}) throw new Error('${name} smoke failed')`
+}
+
+function runChild(name: string, script: string) {
+  const result = spawnSync(
+    execPath,
+    [
+      '--input-type=module',
+      '--eval',
+      `let deferredError; process.once('uncaughtException', (error) => { deferredError ??= error }); process.once('unhandledRejection', (error) => { deferredError ??= error }); try { const { createRequire } = await import('node:module'); const require = createRequire(import.meta.url); ${script}; await Promise.resolve(); await new Promise((resolve) => setImmediate(resolve)); if (deferredError) throw deferredError; process.exit(0) } catch (error) { console.error(error); process.exit(1) }`,
+    ],
+    { encoding: 'utf8', timeout: childTimeout },
+  )
+
+  if (result.error?.code === 'ETIMEDOUT') {
+    throw new Error(
+      `${name}: child timed out after ${childTimeout}ms (signal: ${result.signal})`,
+    )
+  }
+  if (result.signal !== null) {
+    throw new Error(`${name}: child exited from signal ${result.signal}`)
+  }
+  if (result.error) {
+    throw new Error(`${name}: child spawn failed: ${result.error.message}`)
+  }
+
+  expect(result.status, `${name}: ${result.stderr}`).toBe(0)
+}
+
+const runtimeKey = JSON.stringify(`@reatom/${VERSION}`)
+const legacyBundle = `const VERSION = 'legacy'; let runtime = globalThis.__REATOM; if (runtime === undefined) { runtime = { version: VERSION, extensions: [] }; globalThis.__REATOM = runtime } else if (Array.isArray(runtime)) { runtime = { version: VERSION, extensions: runtime }; globalThis.__REATOM = runtime } if (runtime.version !== VERSION) throw new Error('legacy runtime collision'); const state = runtime.state ??= { value: 0 }; state.value++; export { runtime, state, VERSION }`
+
+test(
+  'keeps runtime helpers stable without claiming the legacy global',
+  () => {
+    const fixture = copyRuntime('esm', 'standalone')
+
+    runChild(
+      'standalone runtime',
+      `delete globalThis.__REATOM; ${loadRuntime('runtime', fixture)}; const firstGlobal = runtime.ensureReatomGlobal(); const secondGlobal = runtime.ensureReatomGlobal(); if (firstGlobal !== secondGlobal || firstGlobal.version !== runtime.VERSION || firstGlobal.extensions !== runtime.EXTENSIONS) throw new Error('runtime helper contract changed'); const firstSlot = runtime._createGlobal('runtime-isolation.helper', () => ({ value: 1 })); const secondSlot = runtime._createGlobal('runtime-isolation.helper', () => ({ value: 2 })); if (firstSlot !== secondSlot || secondSlot.value !== 1) throw new Error('runtime slot contract changed'); if (Object.hasOwn(globalThis, '__REATOM')) throw new Error('__REATOM is claimed'); ${smokeRuntime('runtime', 'standaloneSmoke', 1)}`,
+    )
+  },
+  testTimeout,
+)
+
+test.each([
+  { legacyFirst: true, name: 'legacy before current' },
+  { legacyFirst: false, name: 'current before legacy' },
+])(
+  'coexists when loaded $name',
+  ({ legacyFirst }) => {
+    const currentFixture = copyRuntime('esm', 'current-runtime')
+    const legacyFixture = writeFixture('esm', 'legacy-runtime', legacyBundle)
+    const loadCurrent = loadRuntime('runtime', currentFixture)
+    const loadLegacy = loadRuntime('legacy', legacyFixture)
+    const loadFirst = legacyFirst
+      ? `${loadLegacy}; ${loadCurrent}`
+      : `${loadCurrent}; ${loadLegacy}`
+
+    runChild(
+      legacyFirst ? 'legacy runtime first' : 'current runtime first',
+      `delete globalThis.__REATOM; ${loadFirst}; ${smokeRuntime('runtime', 'legacyOrderSmoke', 1)}; if (globalThis.__REATOM !== legacy.runtime || legacy.state.value !== 1) throw new Error('legacy runtime changed')`,
+    )
+  },
+  testTimeout,
+)
+
+test(
+  'falls back locally when the symbol carrier is already occupied',
+  () => {
+    const fixture = copyRuntime('esm', 'occupied-carrier')
+
+    runChild(
+      'occupied symbol carrier',
+      `delete globalThis.__REATOM; const key = Symbol.for(${runtimeKey}); const foreign = { owner: 'host' }; Object.defineProperty(globalThis, key, { value: foreign }); ${loadRuntime('runtime', fixture)}; const firstGlobal = runtime.ensureReatomGlobal(); const secondGlobal = runtime.ensureReatomGlobal(); if (firstGlobal === foreign || firstGlobal !== secondGlobal) throw new Error('local fallback is unstable'); if (Object.getOwnPropertyDescriptor(globalThis, key)?.value !== foreign) throw new Error('foreign carrier changed'); if (Object.hasOwn(globalThis, '__REATOM')) throw new Error('__REATOM is claimed'); ${smokeRuntime('runtime', 'occupiedCarrierSmoke', 1)}`,
+    )
+  },
+  testTimeout,
+)
+
+test.each([
+  { firstFormat: 'esm', name: 'two ESM copies', secondFormat: 'esm' },
+  { firstFormat: 'esm', name: 'ESM and CJS copies', secondFormat: 'cjs' },
+] satisfies Array<{
+  firstFormat: Format
+  name: string
+  secondFormat: Format
+}>)(
+  'shares one runtime across compatible $name',
+  ({ firstFormat, secondFormat }) => {
+    const firstFixture = copyRuntime(firstFormat, 'compatible-first')
+    const secondFixture = copyRuntime(secondFormat, 'compatible-second')
+
+    runChild(
+      `compatible ${firstFormat}/${secondFormat}`,
+      `delete globalThis.__REATOM; ${loadRuntime('first', firstFixture)}; const state = first.atom(0, 'runtime-isolation.shared'); state.set(7); const count = first.context.count; ${loadRuntime('second', secondFixture)}; if (first.context !== second.context || first.STACK !== second.STACK || first.EXTENSIONS !== second.EXTENSIONS || second.context.count !== count || state() !== 7) throw new Error('compatible copies do not share one runtime'); const derived = second.computed(() => state() * 2, 'runtime-isolation.cross-copy'); let observed; const unsubscribe = derived.subscribe((value) => { observed = value }); state.set(8); await Promise.resolve(); if (derived() !== 16 || observed !== 16) throw new Error('cross-copy reactivity failed'); unsubscribe()`,
+    )
+  },
+  testTimeout,
+)
+
+test.each([
+  {
+    firstFormat: 'esm',
+    firstVersion: 'runtime-A',
+    name: 'two ESM copies',
+    secondFormat: 'esm',
+    secondVersion: 'runtime-B',
+  },
+  {
+    firstFormat: 'cjs',
+    firstVersion: 'runtime-B',
+    name: 'CJS before ESM',
+    secondFormat: 'esm',
+    secondVersion: 'runtime-A',
+  },
+] satisfies Array<{
+  firstFormat: Format
+  firstVersion: string
+  name: string
+  secondFormat: Format
+  secondVersion: string
+}>)(
+  'isolates incompatible $name',
+  ({ firstFormat, firstVersion, secondFormat, secondVersion }) => {
+    const firstFixture = copyRuntime(
+      firstFormat,
+      'incompatible-first',
+      firstVersion,
+    )
+    const secondFixture = copyRuntime(
+      secondFormat,
+      'incompatible-second',
+      secondVersion,
+    )
+
+    runChild(
+      `incompatible ${firstFormat}/${secondFormat}`,
+      `delete globalThis.__REATOM; ${loadRuntime('first', firstFixture)}; ${loadRuntime('second', secondFixture)}; if (first.VERSION !== ${JSON.stringify(firstVersion)} || second.VERSION !== ${JSON.stringify(secondVersion)}) throw new Error('fixture VERSION was not mutated'); if (first.context === second.context || first.STACK === second.STACK || first.EXTENSIONS === second.EXTENSIONS) throw new Error('incompatible copies share internals'); const firstSlot = first._createGlobal('runtime-isolation.versioned-slot', () => ({ version: first.VERSION })); const secondSlot = second._createGlobal('runtime-isolation.versioned-slot', () => ({ version: second.VERSION })); if (firstSlot === secondSlot || firstSlot.version !== first.VERSION || secondSlot.version !== second.VERSION) throw new Error('incompatible copies share a runtime slot'); ${smokeRuntime('first', 'firstVersionSmoke', 1)}; ${smokeRuntime('second', 'secondVersionSmoke', 2)}`,
+    )
+  },
+  testTimeout,
+)

--- a/packages/core/src/persist/web-storage/indexedDb.test.browser.ts
+++ b/packages/core/src/persist/web-storage/indexedDb.test.browser.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from 'test'
 
-import { atom } from '../../core'
+import { atom, ensureReatomGlobal } from '../../core'
 import { wrap } from '../../methods'
 import { sleep } from '../../utils'
 import type { PersistRecord } from '../index'
@@ -239,10 +239,12 @@ describe('cold-start rehydration with multiple atoms', () => {
 
   // Reset the lazy `idb-keyval` import so each test exercises the cold-start path.
   beforeEach(() => {
-    const rt = (globalThis as any).__REATOM as { persistIndexedDbLazy?: any }
-    if (rt?.persistIndexedDbLazy) {
-      rt.persistIndexedDbLazy.promise = null
-      rt.persistIndexedDbLazy.module = null
+    const idbLazy = ensureReatomGlobal().persistIndexedDbLazy as
+      | { promise: Promise<any> | null; module: any }
+      | undefined
+    if (idbLazy) {
+      idbLazy.promise = null
+      idbLazy.module = null
     }
   })
 


### PR DESCRIPTION
## Summary

Reatom now stores its shared runtime under a symbol keyed by the runtime ABI (`VERSION`) instead of claiming `globalThis.__REATOM`.

Compatible copies still share one context and default root, including ESM/CJS duplicates. Incompatible versions receive isolated runtimes and no longer throw during import. The legacy `__REATOM` key remains untouched.

## Rationale

Third-party embeds cannot control which Reatom version is already present on the host page. A version conflict must not break either the host application or the embedded widget.

For example:

```html
<script src="host-with-reatom-A.js"></script>
<script src="widget-with-reatom-B.js"></script>
```

Both bundles now load and operate independently without a version-conflict exception.

## Testing

Covers both legacy/current load orders, compatible and incompatible ESM/CJS copies, shared-root behavior, cross-copy reactivity, and runtime isolation.
