### PR TITLE
fix(core): restore omitted keys in reatomRecord.reset

### DIFF
--- a/packages/core/src/primitives/reatomRecord.test.ts
+++ b/packages/core/src/primitives/reatomRecord.test.ts
@@ -41,4 +41,14 @@ describe('reatomRecord', () => {
       senator: false,
     })
   })
+
+  test('should restore an omitted key on reset', () => {
+    const record = reatomRecord({ a: 1, b: 2 })
+
+    record.merge({ b: 3 })
+    record.omit('a')
+    record.reset('a')
+
+    expect(record()).toEqual({ a: 1, b: 3 })
+  })
 })

--- a/packages/core/src/primitives/reatomRecord.ts
+++ b/packages/core/src/primitives/reatomRecord.ts
@@ -59,18 +59,17 @@ export const reatomRecord = <T extends Rec>(
           // @ts-ignore
           (prev) => {
             if (keys.length === 0) return initState
-            const next = {} as T
+            const next = { ...prev } as T
             let changed = false
-            for (const key in prev) {
-              if (keys.includes(key)) {
-                if (key in initState) {
+            for (const key of keys) {
+              if (key in initState) {
+                if (!(key in prev) || !Object.is(prev[key], initState[key])) {
                   next[key] = initState[key]
-                  changed ||= !Object.is(prev[key], initState[key])
-                } else {
-                  changed ||= key in prev
+                  changed = true
                 }
-              } else {
-                next[key] = prev[key]
+              } else if (key in prev) {
+                delete next[key]
+                changed = true
               }
             }
             return changed ? next : prev


### PR DESCRIPTION
## Summary

Fix `reset(key)` so it restores a key previously removed with `omit(key)` without affecting other values.

```ts
const record = reatomRecord({ a: 1, b: 2 })

record.omit("a")
record.reset("a")

record() // { a: 1, b: 2 }
```

Added a regression test. All `@reatom/core` unit tests pass.