### PR TITLE
fix(react): preserve atom setter type in useAtom

### DIFF
--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -25,9 +25,7 @@ export const useAtom: {
     options?: { subscribe?: boolean },
   ): [
     AtomState<Target>,
-    Target extends Atom<any, infer Params>
-      ? (...args: Params) => AtomState<Target>
-      : undefined,
+    Target extends Atom<any, any[]> ? Target['set'] : undefined,
     Target,
     Frame,
   ]


### PR DESCRIPTION
Closes #1293

`useAtom` now exposes the target atom's `set` type instead of reconstructing it from atom params. This enables functional updaters and preserves custom setter overloads such as `UrlAtom.set`.

Tests: `pnpm --filter @reatom/react run test`
Build: `pnpm --filter @reatom/react run build`