### PR TITLE
fix(core): mock only the target computation to keep withAsync processing mocked calls

### DIFF
--- a/packages/core/src/async/withAsync.test.ts
+++ b/packages/core/src/async/withAsync.test.ts
@@ -120,6 +120,36 @@ test('mocked rejection reaches the caller without an unhandled rejection', async
   }
 })
 
+// the reactive counterpart of the mocked action case above
+test('mocked computed rejection is processed by withAsync without an unhandled rejection', async () => {
+  const name = 'mockComputedReject'
+  const data = computed(async () => 'real', name).extend(withAsync())
+  const unmock = mock(data, () => Promise.reject(new Error('mocked-reactive')))
+
+  const rejections: unknown[] = []
+  const listener = (reason: unknown) => rejections.push(reason)
+  process.on('unhandledRejection', listener)
+
+  try {
+    // connection triggers the mocked computation, nobody consumes the promise
+    expect(data.ready()).toBe(false)
+
+    // let the rejection processing and the unhandledRejection event pass
+    await wrap(sleep())
+
+    expect(data.error()?.message).toBe('mocked-reactive')
+    expect(data.ready()).toBe(true)
+    expect(
+      rejections.filter(
+        (reason) => (reason as Error)?.message === 'mocked-reactive',
+      ),
+    ).toEqual([])
+  } finally {
+    process.off('unhandledRejection', listener)
+    unmock()
+  }
+})
+
 test('abort rejection settles without calling onReject', async () => {
   const fetch = action(async (shouldAbort: boolean) => {
     await wrap(sleep())

--- a/packages/core/src/async/withAsync.test.ts
+++ b/packages/core/src/async/withAsync.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi } from 'test'
 
-import { _read, action, atom, computed } from '../core'
+import { _read, action, atom, computed, mock } from '../core'
 import { withCallHook } from '../extensions'
 import { retryComputed, wrap } from '../methods'
 import { noop, sleep, throwAbort } from '../utils'
@@ -85,6 +85,39 @@ test('action error handling', async () => {
     payload: 'Success',
     params: [false],
   })
+})
+
+// https://github.com/reatom/reatom/issues/1291
+test('mocked rejection reaches the caller without an unhandled rejection', async () => {
+  const name = 'mockAsyncReject'
+  const fetchSmth = action(async () => 'real', name).extend(withAsync())
+  const unmock = mock(fetchSmth, () => Promise.reject(new Error('mocked')))
+
+  const rejections: unknown[] = []
+  const listener = (reason: unknown) => rejections.push(reason)
+  process.on('unhandledRejection', listener)
+
+  try {
+    let caught: unknown
+    try {
+      await wrap(fetchSmth())
+    } catch (error) {
+      caught = error
+    }
+    expect((caught as Error).message).toBe('mocked')
+
+    expect(fetchSmth.error()?.message).toBe('mocked')
+    expect(fetchSmth.ready()).toBe(true)
+
+    // let a possible unhandledRejection event fire
+    await new Promise((resolve) => setTimeout(resolve))
+    expect(
+      rejections.filter((reason) => (reason as Error)?.message === 'mocked'),
+    ).toEqual([])
+  } finally {
+    process.off('unhandledRejection', listener)
+    unmock()
+  }
 })
 
 test('abort rejection settles without calling onReject', async () => {

--- a/packages/core/src/core/atom.test.ts
+++ b/packages/core/src/core/atom.test.ts
@@ -597,3 +597,16 @@ test('mock action returns the mocked payload', () => {
   unmock()
   expect(doSmth(1)).toBe(2)
 })
+
+test('mock atom intercepts set', () => {
+  const name = 'mockAtom'
+  const counter = atom(0, name)
+  const unmock = mock(counter, (value: number) => value + 100)
+
+  counter.set(1)
+  expect(counter()).toBe(101)
+
+  unmock()
+  counter.set(2)
+  expect(counter()).toBe(2)
+})

--- a/packages/core/src/core/atom.test.ts
+++ b/packages/core/src/core/atom.test.ts
@@ -4,12 +4,14 @@ import { withComputed } from '../extensions'
 import { identity } from '../utils'
 import {
   _read,
+  action,
   type Atom,
   atom,
   computed,
   context,
   createAtom,
   isConnected,
+  mock,
   notify,
   top,
   withMiddleware,
@@ -583,4 +585,15 @@ test('subscribe without errorCb still throws on init', () => {
   }, `${name}.dep`)
 
   expect(() => dep.subscribe(() => {})).toThrow(name)
+})
+
+test('mock action returns the mocked payload', () => {
+  const name = 'mockAction'
+  const doSmth = action((n: number) => n * 2, name)
+  const unmock = mock(doSmth, (n) => n * 10)
+
+  expect(doSmth(1)).toBe(10)
+
+  unmock()
+  expect(doSmth(1)).toBe(2)
 })

--- a/packages/core/src/core/atom.ts
+++ b/packages/core/src/core/atom.ts
@@ -1520,6 +1520,9 @@ export let bind = <Params extends any[], Payload>(
  * custom callback function for the duration of the mock. This is useful for
  * isolating units of code during testing and controlling their behavior.
  *
+ * Only the target's own computation is replaced: extensions (`withAsync` and
+ * so on) keep processing the mocked calls and may transform the `cb` params.
+ *
  * @template Params - The parameter types of the target atom/action
  * @template Payload - The return type of the target atom/action
  * @param target - The atom or action to mock
@@ -1541,14 +1544,16 @@ export let mock = <Params extends any[], Payload>(
 
     return cb(...params)
   }
-  // For an action wrap only the user computed (like `withActionMiddleware`)
-  // to keep extensions (`withAsync` and so on) processing the mocked payload.
-  let anchor = target.__reatom.reactive ? cacheMiddleware : actionMiddleware
-  let anchorIdx = target.__reatom.middlewares.indexOf(anchor)
-  if (anchorIdx !== -1) {
-    target.__reatom.middlewares.splice(anchorIdx, 0, mockMiddleware)
+  // Keep extensions processing the mocked payload: wrap an action's computed,
+  // for an atom stay outside `computedMiddleware` to keep intercepting `.set`.
+  let { middlewares, reactive } = target.__reatom
+  let kernelIdx = middlewares.indexOf(
+    reactive ? computedMiddleware : actionMiddleware,
+  )
+  if (kernelIdx === -1) {
+    middlewares.push(mockMiddleware)
   } else {
-    target.__reatom.middlewares.push(mockMiddleware)
+    middlewares.splice(kernelIdx + (reactive ? 1 : 0), 0, mockMiddleware)
   }
   _recompile(target)
   return () => {

--- a/packages/core/src/core/atom.ts
+++ b/packages/core/src/core/atom.ts
@@ -1541,9 +1541,12 @@ export let mock = <Params extends any[], Payload>(
 
     return cb(...params)
   }
-  let cacheMiddlewareIdx = target.__reatom.middlewares.indexOf(cacheMiddleware)
-  if (cacheMiddlewareIdx !== -1) {
-    target.__reatom.middlewares.splice(cacheMiddlewareIdx, 0, mockMiddleware)
+  // For an action wrap only the user computed (like `withActionMiddleware`)
+  // to keep extensions (`withAsync` and so on) processing the mocked payload.
+  let anchor = target.__reatom.reactive ? cacheMiddleware : actionMiddleware
+  let anchorIdx = target.__reatom.middlewares.indexOf(anchor)
+  if (anchorIdx !== -1) {
+    target.__reatom.middlewares.splice(anchorIdx, 0, mockMiddleware)
   } else {
     target.__reatom.middlewares.push(mockMiddleware)
   }


### PR DESCRIPTION
Fixes #1291

## Problem

When an action extended with `withAsync()` is mocked via `mock()` and the mock returns a rejected promise, the caller catches a confusing sync `TypeError` instead of the mock error, and the original rejected promise is reported as an unhandled rejection:

```
caught by caller: state.at is not a function
UNHANDLED REJECTION: mockRejectedValueOnce error
```

While reproducing it turned out the problem is broader: **`mock()` on any action was broken** — even `mock(doSmth, () => 42)` returned `undefined` or threw the same `TypeError` (there were no tests covering `mock` at all).

## Root cause

`_recompile` composes `middlewares` so that the last element is the outermost one. `mock()` inserted its middleware right before the core `cacheMiddleware` — i.e. **outside** both `actionMiddleware` and the extensions middlewares (`asyncMiddleware` etc.) — and never called `next`:

```
before: [userFn, actionMiddleware, asyncMiddleware, mockMiddleware, cacheMiddleware]
```

So for an action the raw mocked payload replaced the whole calls list:

- `frame.state` became the raw promise instead of `[{ params, payload }]`, and the `state.at(-1)!.payload` unwrap threw the sync `TypeError`;
- `asyncMiddleware` never ran, so nobody subscribed to the promise → unhandled rejection, `error()` stayed empty, `pending` never settled.

Notably, this could not be fixed inside `withAsync` at all: its middleware simply never executed under a mock.

## Fix

Anchor the mock middleware at the kernel middleware instead, so the mock replaces **only the target's own computation** while the kernel bookkeeping and extensions process the mocked call as a regular one:

```
after:  [userFn, mockMiddleware, actionMiddleware, asyncMiddleware, cacheMiddleware]  // action
after:  [userFn, computedMiddleware, mockMiddleware, asyncMiddleware, cacheMiddleware] // atom
```

- **Actions**: inserted at the `actionMiddleware` position (the exact place `withActionMiddleware` uses), so the calls list wraps the mocked payload.
- **Atoms**: inserted right outside `computedMiddleware` — for a plain atom without extensions this position is identical to the previous one (`.set` interception untouched), while a mocked `withAsync` computed now goes through the async machinery too (second commit pair, same bug class for reactive targets).

As a result the caller receives the actual mock rejection, `error()` / `ready()` / `onReject` / `retry` work, and no rejection is left unhandled.

### Design note

A same-size alternative — keeping the old position and just wrapping the payload into the calls-list shape — would fix the crash and the unhandled rejection, but leave the `mock` + `withAsync` combination half-broken (`pending` stuck forever, `error()` empty, `status` inconsistent). The chosen placement follows the "mock replaces the implementation, not the framework" semantics, consistent with the existing `withActionMiddleware` precedent. Side effect worth noting: invalidation-place extensions (`withTap`, `withChangeHook`, `withParams`, …) now observe mocked calls — all of them call `next` unconditionally and return its result, so the "mock wins" invariant holds (documented in the `mock` JSDoc).

## Tests

- `mocked rejection reaches the caller without an unhandled rejection` — the exact issue scenario, including an `unhandledRejection` listener assertion;
- `mocked computed rejection is processed by withAsync without an unhandled rejection` — the reactive counterpart;
- `mock action returns the mocked payload` / `mock atom intercepts set` — pin the base `mock` contract for actions and plain atoms.

Each fix commit is preceded by a commit with the reproducing tests. Full `@reatom/core` suite (422 tests, node + typecheck) passes.

## Known limitations (pre-existing, out of scope)

- Under a mock the reactive `pubs` are not linked, so `onFulfill`/`onReject` receive `params = []` for reactive targets;
- a mocked computed that already accumulated real dependencies recomputes on every unsubscribed read (kernel memoization is shadowed by the mock, as before);
- a hypothetical non-reactive target without `actionMiddleware` would silently fall back to the old placement (unreachable via the public API).