### PR TITLE
fix(jsx): sync aria-checked with model:checked

### DIFF
--- a/packages/jsx/src/index.test.tsx
+++ b/packages/jsx/src/index.test.tsx
@@ -1334,14 +1334,12 @@ test('model:field binds checkbox checked', () =>
 test('model:checked synchronizes aria-checked', () =>
   context.start(async () => {
     const checked = atom(false, 'checked')
-    const input = instance(
-      HTMLInputElement,
-      <input model:checked={checked} attr:type="checkbox" />,
-    )
+    const input = instance(HTMLInputElement, <input model:checked={checked} />)
 
     mount(parent(), input)
     await wrap(sleep())
 
+    expect(input.type).toBe('checkbox')
     expect(input.checked).toBe(false)
     expect(input.getAttribute('aria-checked')).toBe('false')
 
@@ -1357,6 +1355,26 @@ test('model:checked synchronizes aria-checked', () =>
 
     expect(checked()).toBe(false)
     expect(input.getAttribute('aria-checked')).toBe('false')
+  }))
+
+test('model:checked preserves an explicit input type', () =>
+  context.start(async () => {
+    const checked = atom(false, 'checked')
+    const typeBefore = instance(
+      HTMLInputElement,
+      <input attr:type="radio" model:checked={checked} />,
+    )
+    const typeAfter = instance(
+      HTMLInputElement,
+      <input model:checked={checked} attr:type="radio" />,
+    )
+
+    mount(parent(), typeBefore)
+    mount(parent(), typeAfter)
+    await wrap(sleep())
+
+    expect(typeBefore.type).toBe('radio')
+    expect(typeAfter.type).toBe('radio')
   }))
 
 test('model:field inside a function child does not track the field value', () =>

--- a/packages/jsx/src/index.test.tsx
+++ b/packages/jsx/src/index.test.tsx
@@ -1331,6 +1331,34 @@ test('model:field binds checkbox checked', () =>
     expect(input.checked).toBe(true)
   }))
 
+test('model:checked synchronizes aria-checked', () =>
+  context.start(async () => {
+    const checked = atom(false, 'checked')
+    const input = instance(
+      HTMLInputElement,
+      <input model:checked={checked} attr:type="checkbox" />,
+    )
+
+    mount(parent(), input)
+    await wrap(sleep())
+
+    expect(input.checked).toBe(false)
+    expect(input.getAttribute('aria-checked')).toBe('false')
+
+    checked.set(true)
+    await wrap(sleep())
+
+    expect(input.checked).toBe(true)
+    expect(input.getAttribute('aria-checked')).toBe('true')
+
+    input.checked = false
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    await wrap(sleep())
+
+    expect(checked()).toBe(false)
+    expect(input.getAttribute('aria-checked')).toBe('false')
+  }))
+
 test('model:field inside a function child does not track the field value', () =>
   context.start(async () => {
     const field = reatomField('a', 'wrappedField')

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -801,6 +801,13 @@ let setProp = (dom: DomApis, element: JSX.Element, key: string, value: any) => {
 
   if (key.startsWith('model:')) {
     key = key.slice(6)
+    if (key === 'checked') {
+      let setChecked = setter
+      setter = (val) => {
+        setChecked(val)
+        set(dom, element, 'aria-checked', val)
+      }
+    }
     setProp(dom, element, 'on:input', (event: any) => {
       if (!event.target.validity.badInput) {
         let val = event.target[key]

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -802,6 +802,12 @@ let setProp = (dom: DomApis, element: JSX.Element, key: string, value: any) => {
   if (key.startsWith('model:')) {
     key = key.slice(6)
     if (key === 'checked') {
+      if (
+        element instanceof dom.HTMLInputElement &&
+        !element.hasAttribute('type')
+      ) {
+        set(dom, element, 'attr:type', 'checkbox')
+      }
       let setChecked = setter
       setter = (val) => {
         setChecked(val)


### PR DESCRIPTION
## Summary

- synchronize `aria-checked` whenever `model:checked` updates the checked property
- cover initial, atom-driven, and input-driven changes

Fixes #1013

## Testing

- `pnpm --filter @reatom/jsx test`
- `pnpm --filter @reatom/jsx run build`
