### PR TITLE
test(core): failing test for cross-tab reset to undefined

### DIFF
--- a/packages/core/src/persist/web-storage/localStorage.test.browser.ts
+++ b/packages/core/src/persist/web-storage/localStorage.test.browser.ts
@@ -153,6 +153,54 @@ test('fromSnapshot and toSnapshot', () => {
   expect(JSON.parse(persistedValue!).data).toEqual([['c', 3]])
 })
 
+test('localStorage propagates a reset to undefined to another tab', () => {
+  const key = uniqueKey('undefined-reset')
+  const owner = atom<string | undefined>(
+    'initial',
+    'localStorageResetOwnerAtom',
+  ).extend(withLocalStorage(key))
+  const ownerUnsubscribe = owner.subscribe(() => {})
+  notify()
+
+  owner.set('value')
+
+  // Another tab, opened while the value is set: it reads the persisted value.
+  const other = atom<string | undefined>(
+    'initial',
+    'localStorageResetOtherAtom',
+  ).extend(withLocalStorage(key))
+  const otherUnsubscribe = other.subscribe(() => {})
+  notify()
+
+  expect(other()).toBe('value')
+
+  // A regular change reaches the other tab.
+  owner.set('other-value')
+  globalThis.dispatchEvent(
+    new StorageEvent('storage', {
+      key,
+      newValue: localStorage.getItem(key),
+      storageArea: localStorage,
+    }),
+  )
+
+  expect(other()).toBe('other-value')
+
+  // A reset to undefined should reach it the same way.
+  owner.set(undefined)
+  globalThis.dispatchEvent(
+    new StorageEvent('storage', {
+      key,
+      newValue: localStorage.getItem(key),
+      storageArea: localStorage,
+    }),
+  )
+
+  ownerUnsubscribe()
+  otherUnsubscribe()
+  expect(other()).toBeUndefined()
+})
+
 test('localStorage deletion events invalidate subscribers', () => {
   const key = uniqueKey('clear')
   const storedRecord = createRecord('stored')


### PR DESCRIPTION
Failing test for #1334 — no fix, just the repro.

A regular cross-tab change reaches the other tab; a reset to `undefined` does not. The test asserts both steps, so the first one documents that the mechanism works and the second one isolates the bug.

Run: `pnpm --filter @reatom/core run test:browser`

```
× localStorage propagates a reset to undefined to another tab
AssertionError: expected 'other-value' to be undefined
```
