### PR TITLE
fix(persist): handle async storage rejections

### DIFF
--- a/packages/core/src/persist/index.test.ts
+++ b/packages/core/src/persist/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, subscribe, test, vi } from 'test'
+import { afterEach, describe, expect, subscribe, test, vi } from 'test'
 
 import { wrap } from '..'
 import { action, atom, notify } from '../core'
@@ -19,6 +19,8 @@ const createRecord = <State>(
   version: 0,
   ...overrides,
 })
+
+afterEach(() => vi.restoreAllMocks())
 
 describe('base', () => {
   test('should persist and update state correctly', async () => {
@@ -109,6 +111,37 @@ describe('base', () => {
 })
 
 describe('async', () => {
+  const expectAsyncStorageErrorToBeHandled = async (
+    operation: 'get' | 'set' | 'clear',
+  ) => {
+    const error = new Error(`${operation} failed`)
+    const storage = reatomPersist<string>({
+      name: 'failingAsyncStorage',
+      get: () =>
+        operation === 'get' ? Promise.reject(error) : Promise.resolve(null),
+      set: () =>
+        operation === 'set' ? Promise.reject(error) : Promise.resolve(),
+      clear: () =>
+        operation === 'clear' ? Promise.reject(error) : Promise.resolve(),
+    }).storageAtom()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(noop)
+    const log = vi.spyOn(console, 'log').mockImplementation(noop)
+
+    if (operation === 'get') storage.get({ key: 'test' })
+    if (operation === 'set') storage.set({ key: 'test' }, createRecord('test'))
+    if (operation === 'clear') storage.clear?.({ key: 'test' })
+
+    await wrap(sleep())
+
+    expect(warn).toHaveBeenCalledWith('Error in storage failingAsyncStorage')
+    expect(log).toHaveBeenCalledWith(error)
+  }
+
+  test.each(['get', 'set', 'clear'] as const)(
+    'handles an async storage %s rejection',
+    expectAsyncStorageErrorToBeHandled,
+  )
+
   test('should handle async updates', async () => {
     let trigger = noop
     const number1Atom = atom(0).extend(withSomePersist({ key: 'test' }))
@@ -198,6 +231,39 @@ describe('async', () => {
     unsubscribe()
     expect(target()).toBe('initial')
     expect(getCalls).toBe(1)
+  })
+
+  test('async storage caches rejected reads without revalidation loop', async () => {
+    let getCalls = 0
+    let rejectGet!: (reason?: unknown) => void
+    const error = new Error('get failed')
+    const withAsyncPersist = reatomPersist<string>({
+      name: 'auditAsyncRejectedStorage',
+      get: () => {
+        getCalls++
+        return new Promise<null>((_resolve, reject) => {
+          rejectGet = reject
+        })
+      },
+      set: vi.fn(),
+      subscribe: () => noop,
+    })
+    const target = atom('initial', 'auditAsyncRejectedAtom').extend(
+      withAsyncPersist('rejected-key'),
+    )
+    const warn = vi.spyOn(console, 'warn').mockImplementation(noop)
+    const log = vi.spyOn(console, 'log').mockImplementation(noop)
+    const unsubscribe = target.subscribe(() => {})
+
+    rejectGet(error)
+    await wrap(sleep())
+
+    unsubscribe()
+    expect(getCalls).toBe(1)
+    expect(warn).toHaveBeenCalledWith(
+      'Error in storage auditAsyncRejectedStorage',
+    )
+    expect(log).toHaveBeenCalledWith(error)
   })
 
   test('subscribe false applies async persisted value on init', async () => {

--- a/packages/core/src/persist/index.ts
+++ b/packages/core/src/persist/index.ts
@@ -179,6 +179,10 @@ export const reatomPersist = <Snapshot = unknown, Options extends Rec = {}>(
 ): WithPersist<Snapshot, Options> => {
   const storageAtom = atom((): PersistStorage<Snapshot, Options> => {
     let cache: PersistCache = new Map()
+    const handleError = (error: unknown) => {
+      console.warn(`Error in storage ${storage.name}`)
+      console.log(error)
+    }
 
     return {
       name: storage.name,
@@ -199,15 +203,21 @@ export const reatomPersist = <Snapshot = unknown, Options extends Rec = {}>(
           let recOrPromise = storage.get({ ...options, cache })
 
           if (recOrPromise instanceof Promise) {
-            return recOrPromise.then(
-              bind((rec) => {
-                let freshRec = rec && rec.to >= Date.now() ? rec : null
-                if (!cache.has(options.key)) {
-                  cache.set(options.key, freshRec)
-                }
-                return freshRec
-              }),
-            )
+            return recOrPromise
+              .then(
+                bind((rec) => {
+                  let freshRec = rec && rec.to >= Date.now() ? rec : null
+                  if (!cache.has(options.key)) {
+                    cache.set(options.key, freshRec)
+                  }
+                  return freshRec
+                }),
+              )
+              .catch((error) => {
+                handleError(error)
+                if (!cache.has(options.key)) cache.set(options.key, null)
+                return null
+              })
           }
 
           let rec = recOrPromise
@@ -218,28 +228,27 @@ export const reatomPersist = <Snapshot = unknown, Options extends Rec = {}>(
 
           return rec
         } catch (error) {
-          console.warn(`Error in storage ${storage.name}`)
-          console.log(error)
+          handleError(error)
           return null
         }
       },
       set(options, rec) {
         try {
           cache.set(options.key, rec)
-          return storage.set({ ...options, cache }, rec)
+          const result = storage.set({ ...options, cache }, rec)
+          return result instanceof Promise ? result.catch(handleError) : result
         } catch (error) {
-          console.warn(`Error in storage ${storage.name}`)
-          console.log(error)
+          handleError(error)
           /* ignore */
         }
       },
       clear(options) {
         try {
           cache.delete(options.key)
-          return storage.clear?.({ ...options, cache })
+          const result = storage.clear?.({ ...options, cache })
+          return result instanceof Promise ? result.catch(handleError) : result
         } catch (error) {
-          console.warn(`Error in storage ${storage.name}`)
-          console.log(error)
+          handleError(error)
           /* ignore */
         }
       },


### PR DESCRIPTION
## Summary

Fix async persist storage rejections.

Rejected `get`, `set`, and `clear` promises are now handled instead of becoming unhandled rejections. Failed async reads are cached as `null` to avoid a revalidation loop while preserving any newer cached value.

## Example

```ts
const persist = reatomPersist({
  name: "storage",
  get: async () => Promise.reject(new Error("IndexedDB unavailable")),
  set: async () => Promise.reject(new Error("IndexedDB unavailable")),
})
```

The atom keeps its current state and reports the storage error without producing an unhandled rejection.

## Tests

- `pnpm --filter @reatom/core run test:unit`
- `pnpm --filter @reatom/core run test:browser`