### PR TITLE
fix(persist): stop default snapshots from expiring after 25 days

### DIFF
--- a/docs/src/content/docs/handbook/persist.md
+++ b/docs/src/content/docs/handbook/persist.md
@@ -428,16 +428,16 @@ const configuredAtom = atom({ name: '', age: 0 }).extend(
 
 ### Configuration Reference
 
-| Option         | Type                         | Default                       | Description                                                            |
-| -------------- | ---------------------------- | ----------------------------- | ---------------------------------------------------------------------- |
-| `key`          | `string`                     | **required**                  | Unique key for storage                                                 |
-| `toSnapshot`   | `(state) => any`             | `() => target.toJSON()`       | Serialize state before saving                                          |
-| `fromSnapshot` | `(snapshot) => state`        | `target.fromJSON` or identity | Deserialize state after loading                                        |
-| `schema`       | `StandardSchemaV1`           | `undefined`                   | Schema to validate and transform data                                  |
-| `version`      | `number \| string`           | `0`                           | Version number for migration                                           |
-| `migration`    | `(record, version) => state` | `undefined`                   | Migrate old data to current version                                    |
-| `time`         | `number`                     | `PERSIST_FOREVER`             | TTL in milliseconds; effectively no Reatom-level expiration by default |
-| `subscribe`    | `boolean`                    | `true`                        | Enable cross-tab synchronization                                       |
+| Option         | Type                         | Default                       | Description                           |
+| -------------- | ---------------------------- | ----------------------------- | ------------------------------------- |
+| `key`          | `string`                     | **required**                  | Unique key for storage                |
+| `toSnapshot`   | `(state) => any`             | `() => target.toJSON()`       | Serialize state before saving         |
+| `fromSnapshot` | `(snapshot) => state`        | `target.fromJSON` or identity | Deserialize state after loading       |
+| `schema`       | `StandardSchemaV1`           | `undefined`                   | Schema to validate and transform data |
+| `version`      | `number \| string`           | `0`                           | Version number for migration          |
+| `migration`    | `(record, version) => state` | `undefined`                   | Migrate old data to current version   |
+| `time`         | `number`                     | `Number.MAX_SAFE_INTEGER`     | TTL in milliseconds                   |
+| `subscribe`    | `boolean`                    | `true`                        | Enable cross-tab synchronization      |
 
 ## Cross-Tab Synchronization
 

--- a/docs/src/content/docs/handbook/persist.md
+++ b/docs/src/content/docs/handbook/persist.md
@@ -428,16 +428,16 @@ const configuredAtom = atom({ name: '', age: 0 }).extend(
 
 ### Configuration Reference
 
-| Option         | Type                         | Default                       | Description                           |
-| -------------- | ---------------------------- | ----------------------------- | ------------------------------------- |
-| `key`          | `string`                     | **required**                  | Unique key for storage                |
-| `toSnapshot`   | `(state) => any`             | `() => target.toJSON()`       | Serialize state before saving         |
-| `fromSnapshot` | `(snapshot) => state`        | `target.fromJSON` or identity | Deserialize state after loading       |
-| `schema`       | `StandardSchemaV1`           | `undefined`                   | Schema to validate and transform data |
-| `version`      | `number \| string`           | `0`                           | Version number for migration          |
-| `migration`    | `(record, version) => state` | `undefined`                   | Migrate old data to current version   |
-| `time`         | `number`                     | `MAX_SAFE_TIMEOUT`            | TTL in milliseconds                   |
-| `subscribe`    | `boolean`                    | `true`                        | Enable cross-tab synchronization      |
+| Option         | Type                         | Default                       | Description                                                            |
+| -------------- | ---------------------------- | ----------------------------- | ---------------------------------------------------------------------- |
+| `key`          | `string`                     | **required**                  | Unique key for storage                                                 |
+| `toSnapshot`   | `(state) => any`             | `() => target.toJSON()`       | Serialize state before saving                                          |
+| `fromSnapshot` | `(snapshot) => state`        | `target.fromJSON` or identity | Deserialize state after loading                                        |
+| `schema`       | `StandardSchemaV1`           | `undefined`                   | Schema to validate and transform data                                  |
+| `version`      | `number \| string`           | `0`                           | Version number for migration                                           |
+| `migration`    | `(record, version) => state` | `undefined`                   | Migrate old data to current version                                    |
+| `time`         | `number`                     | `PERSIST_FOREVER`             | TTL in milliseconds; effectively no Reatom-level expiration by default |
+| `subscribe`    | `boolean`                    | `true`                        | Enable cross-tab synchronization                                       |
 
 ## Cross-Tab Synchronization
 

--- a/packages/core/src/persist/index.test.ts
+++ b/packages/core/src/persist/index.test.ts
@@ -20,42 +20,25 @@ const createRecord = <State>(
   ...overrides,
 })
 
-const createJsonStorage = <Snapshot>() => {
-  const records = new Map<string, string>()
-
-  return {
-    records,
-    storage: {
-      name: 'jsonStorage',
-      get({ key }: { key: string }) {
-        const record = records.get(key)
-        return record === undefined
-          ? null
-          : (JSON.parse(record) as PersistRecord<Snapshot>)
-      },
-      set({ key }: { key: string }, record: PersistRecord<Snapshot>) {
-        records.set(key, JSON.stringify(record))
-      },
-    },
-  }
-}
-
 afterEach(() => vi.restoreAllMocks())
 
 describe('base', () => {
   test('default snapshots persist beyond MAX_SAFE_TIMEOUT', () => {
     const now = 1_000
     const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now)
-    const { records, storage } = createJsonStorage<number>()
+    let json = ''
+    const storage = {
+      name: 'jsonStorage',
+      get: () => (json ? (JSON.parse(json) as PersistRecord<number>) : null),
+      set: (_options: unknown, record: PersistRecord<number>) => {
+        json = JSON.stringify(record)
+      },
+    }
 
     const source = atom(0, 'persistForeverSource').extend(
       reatomPersist<number>(storage)('persist-forever'),
     )
     source.set(42)
-
-    expect(JSON.parse(records.get('persist-forever')!).to).toBe(
-      Number.MAX_SAFE_INTEGER,
-    )
 
     dateNow.mockReturnValue(now + MAX_SAFE_TIMEOUT + 1)
     const restored = atom(0, 'persistForeverRestored').extend(
@@ -63,25 +46,6 @@ describe('base', () => {
     )
 
     expect(restored()).toBe(42)
-  })
-
-  test('explicit persist time remains a relative TTL', () => {
-    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(1_000)
-    const { records, storage } = createJsonStorage<number>()
-
-    const source = atom(0, 'persistTtlSource').extend(
-      reatomPersist<number>(storage)({ key: 'persist-ttl', time: 1_000 }),
-    )
-    source.set(42)
-
-    expect(JSON.parse(records.get('persist-ttl')!).to).toBe(2_000)
-
-    dateNow.mockReturnValue(2_001)
-    const restored = atom(0, 'persistTtlRestored').extend(
-      reatomPersist<number>(storage)({ key: 'persist-ttl', time: 1_000 }),
-    )
-
-    expect(restored()).toBe(0)
   })
 
   test('should persist and update state correctly', async () => {

--- a/packages/core/src/persist/index.test.ts
+++ b/packages/core/src/persist/index.test.ts
@@ -23,29 +23,16 @@ const createRecord = <State>(
 afterEach(() => vi.restoreAllMocks())
 
 describe('base', () => {
-  test('default snapshots persist beyond MAX_SAFE_TIMEOUT', () => {
-    const now = 1_000
-    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now)
-    let json = ''
-    const storage = {
-      name: 'jsonStorage',
-      get: () => (json ? (JSON.parse(json) as PersistRecord<number>) : null),
-      set: (_options: unknown, record: PersistRecord<number>) => {
-        json = JSON.stringify(record)
-      },
-    }
-
+  test('snapshots do not expire by default', () => {
+    const storage = createMemStorage({ name: 'persistForever' })
     const source = atom(0, 'persistForeverSource').extend(
       reatomPersist<number>(storage)('persist-forever'),
     )
     source.set(42)
 
-    dateNow.mockReturnValue(now + MAX_SAFE_TIMEOUT + 1)
-    const restored = atom(0, 'persistForeverRestored').extend(
-      reatomPersist<number>(storage)('persist-forever'),
+    expect(storage.snapshotAtom()['persist-forever']?.to).toBe(
+      Number.MAX_SAFE_INTEGER,
     )
-
-    expect(restored()).toBe(42)
   })
 
   test('should persist and update state correctly', async () => {

--- a/packages/core/src/persist/index.test.ts
+++ b/packages/core/src/persist/index.test.ts
@@ -20,9 +20,70 @@ const createRecord = <State>(
   ...overrides,
 })
 
+const createJsonStorage = <Snapshot>() => {
+  const records = new Map<string, string>()
+
+  return {
+    records,
+    storage: {
+      name: 'jsonStorage',
+      get({ key }: { key: string }) {
+        const record = records.get(key)
+        return record === undefined
+          ? null
+          : (JSON.parse(record) as PersistRecord<Snapshot>)
+      },
+      set({ key }: { key: string }, record: PersistRecord<Snapshot>) {
+        records.set(key, JSON.stringify(record))
+      },
+    },
+  }
+}
+
 afterEach(() => vi.restoreAllMocks())
 
 describe('base', () => {
+  test('default snapshots persist beyond MAX_SAFE_TIMEOUT', () => {
+    const now = 1_000
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now)
+    const { records, storage } = createJsonStorage<number>()
+
+    const source = atom(0, 'persistForeverSource').extend(
+      reatomPersist<number>(storage)('persist-forever'),
+    )
+    source.set(42)
+
+    expect(JSON.parse(records.get('persist-forever')!).to).toBe(
+      Number.MAX_SAFE_INTEGER,
+    )
+
+    dateNow.mockReturnValue(now + MAX_SAFE_TIMEOUT + 1)
+    const restored = atom(0, 'persistForeverRestored').extend(
+      reatomPersist<number>(storage)('persist-forever'),
+    )
+
+    expect(restored()).toBe(42)
+  })
+
+  test('explicit persist time remains a relative TTL', () => {
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+    const { records, storage } = createJsonStorage<number>()
+
+    const source = atom(0, 'persistTtlSource').extend(
+      reatomPersist<number>(storage)({ key: 'persist-ttl', time: 1_000 }),
+    )
+    source.set(42)
+
+    expect(JSON.parse(records.get('persist-ttl')!).to).toBe(2_000)
+
+    dateNow.mockReturnValue(2_001)
+    const restored = atom(0, 'persistTtlRestored').extend(
+      reatomPersist<number>(storage)({ key: 'persist-ttl', time: 1_000 }),
+    )
+
+    expect(restored()).toBe(0)
+  })
+
   test('should persist and update state correctly', async () => {
     withSomePersist.storageAtom.set(
       createMemStorage({

--- a/packages/core/src/persist/index.ts
+++ b/packages/core/src/persist/index.ts
@@ -23,15 +23,13 @@ import {
   type Unsubscribe,
 } from '../utils'
 
-export const PERSIST_FOREVER = Number.MAX_SAFE_INTEGER
-
 export interface PersistRecord<Snapshot = unknown> {
   data: Snapshot
   id: number
   // TODO remove?
   timestamp: number
   version: number | string
-  /** Expiration timestamp; `PERSIST_FOREVER` means no practical expiration. */
+  /** Time stamp after which the record is cleared. */
   to: number
 }
 
@@ -126,7 +124,7 @@ export interface WithPersistOptions<State = unknown, Snapshot = unknown> {
    * Number of milliseconds from the snapshot creation time after which it will
    * be deleted.
    *
-   * @defaultValue PERSIST_FOREVER
+   * @defaultValue Number.MAX_SAFE_INTEGER
    */
   time?: number
 
@@ -298,7 +296,7 @@ export const reatomPersist = <Snapshot = unknown, Options extends Rec = {}>(
           ) => AtomState<Target>,
           migration,
           subscribe = !!storage.subscribe,
-          time = PERSIST_FOREVER,
+          time = Number.MAX_SAFE_INTEGER,
           toSnapshot = () => target.toJSON() as Snapshot,
           version = 0,
           schema,
@@ -359,7 +357,7 @@ export const reatomPersist = <Snapshot = unknown, Options extends Rec = {}>(
             data: toSnapshot(state),
             id: random(),
             timestamp,
-            to: Math.min(timestamp + time, PERSIST_FOREVER),
+            to: Math.min(timestamp + time, Number.MAX_SAFE_INTEGER),
             version,
           }
         }
@@ -467,7 +465,7 @@ export const createMemStorage = ({
   subscribe?: boolean
 }): PersistStorage & { snapshotAtom: Atom<Rec<PersistRecord>> } => {
   let timestamp = Date.now()
-  let to = PERSIST_FOREVER
+  let to = Number.MAX_SAFE_INTEGER
   let initState = Object.entries(snapshot).reduce(
     (acc, [key, data]) => (
       (acc[key] = {

--- a/packages/core/src/persist/index.ts
+++ b/packages/core/src/persist/index.ts
@@ -16,7 +16,6 @@ import { memoKey } from '../methods/memo'
 import { peek } from '../methods/peek'
 import {
   type Fn,
-  MAX_SAFE_TIMEOUT,
   noop,
   random,
   type Rec,
@@ -24,13 +23,15 @@ import {
   type Unsubscribe,
 } from '../utils'
 
+export const PERSIST_FOREVER = Number.MAX_SAFE_INTEGER
+
 export interface PersistRecord<Snapshot = unknown> {
   data: Snapshot
   id: number
   // TODO remove?
   timestamp: number
   version: number | string
-  /** Time stamp after which the record is cleared. */
+  /** Expiration timestamp; `PERSIST_FOREVER` means no practical expiration. */
   to: number
 }
 
@@ -125,7 +126,7 @@ export interface WithPersistOptions<State = unknown, Snapshot = unknown> {
    * Number of milliseconds from the snapshot creation time after which it will
    * be deleted.
    *
-   * @defaultValue MAX_SAFE_TIMEOUT
+   * @defaultValue PERSIST_FOREVER
    */
   time?: number
 
@@ -297,7 +298,7 @@ export const reatomPersist = <Snapshot = unknown, Options extends Rec = {}>(
           ) => AtomState<Target>,
           migration,
           subscribe = !!storage.subscribe,
-          time = MAX_SAFE_TIMEOUT,
+          time = PERSIST_FOREVER,
           toSnapshot = () => target.toJSON() as Snapshot,
           version = 0,
           schema,
@@ -352,13 +353,16 @@ export const reatomPersist = <Snapshot = unknown, Options extends Rec = {}>(
 
         let toPersistRecord = (
           state: AtomState<Target>,
-        ): PersistRecord<Snapshot> => ({
-          data: toSnapshot(state),
-          id: random(),
-          timestamp: Date.now(),
-          to: Date.now() + time,
-          version,
-        })
+        ): PersistRecord<Snapshot> => {
+          const timestamp = Date.now()
+          return {
+            data: toSnapshot(state),
+            id: random(),
+            timestamp,
+            to: Math.min(timestamp + time, PERSIST_FOREVER),
+            version,
+          }
+        }
 
         if (subscribe) {
           function withProactivePersist(next: Fn, ...params: any[]) {
@@ -463,7 +467,7 @@ export const createMemStorage = ({
   subscribe?: boolean
 }): PersistStorage & { snapshotAtom: Atom<Rec<PersistRecord>> } => {
   let timestamp = Date.now()
-  let to = timestamp + MAX_SAFE_TIMEOUT
+  let to = PERSIST_FOREVER
   let initState = Object.entries(snapshot).reduce(
     (acc, [key, data]) => (
       (acc[key] = {

--- a/packages/core/src/persist/web-storage/cookie.ts
+++ b/packages/core/src/persist/web-storage/cookie.ts
@@ -1,7 +1,7 @@
 import { ReatomError } from '../../core'
-import { MAX_SAFE_TIMEOUT } from '../../utils'
 import {
   createMemStorage,
+  PERSIST_FOREVER,
   type PersistRecord,
   reatomPersist,
   type WithPersist,
@@ -98,7 +98,7 @@ const calculateExpiration = (options: CookieAttributes): number => {
   if (options.expires !== undefined) {
     return options.expires.getTime()
   }
-  return now + MAX_SAFE_TIMEOUT
+  return PERSIST_FOREVER
 }
 
 export const reatomPersistCookie = (

--- a/packages/core/src/persist/web-storage/cookie.ts
+++ b/packages/core/src/persist/web-storage/cookie.ts
@@ -1,7 +1,6 @@
 import { ReatomError } from '../../core'
 import {
   createMemStorage,
-  PERSIST_FOREVER,
   type PersistRecord,
   reatomPersist,
   type WithPersist,
@@ -98,7 +97,7 @@ const calculateExpiration = (options: CookieAttributes): number => {
   if (options.expires !== undefined) {
     return options.expires.getTime()
   }
-  return PERSIST_FOREVER
+  return Number.MAX_SAFE_INTEGER
 }
 
 export const reatomPersistCookie = (


### PR DESCRIPTION
Closes #1323.

## Problem

`WithPersistOptions.time` used `MAX_SAFE_TIMEOUT` as its default. That constant represents the maximum safe `setTimeout` delay (~24.9 days), but persistence does not schedule a timer: it stores an absolute `to` timestamp and compares it with `Date.now()` when reading.

As a result, untouched snapshots written by local storage, session storage, or cookie persistence silently expired after approximately 25 days.

`Infinity` is not a safe replacement because JSON serializes it as `null`.

## Changes

- Default `time` to `Number.MAX_SAFE_INTEGER`.
- Compute the snapshot timestamp once and cap the absolute expiration timestamp at `Number.MAX_SAFE_INTEGER`.
- Use the same default for in-memory and cookie fallback records.
- Update the persistence documentation.
- Add a minimal regression test for the default expiration timestamp.

Explicit TTL behavior is preserved, and no new public API is introduced.

## Testing

- `pnpm --filter @reatom/core exec vitest run src/persist/index.test.ts` — 15 passed
- `pnpm --filter @reatom/core run test:unit` — 428 passed
- `pnpm --filter @reatom/core run test:browser` — 114 passed
- `pnpm --filter @reatom/core run build`
- Prettier check
- `git diff --check`

## Notes

Existing records retain their previously stored expiration timestamp until they are rewritten. Cookie lifetime may still be limited by browser-specific caps.
