### PR TITLE
fix(core): log computed initialization

### DIFF
--- a/packages/core/src/methods/connectLogger.test.ts
+++ b/packages/core/src/methods/connectLogger.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi } from 'test'
 
-import { sleep, wrap } from '..'
+import { peek, sleep, wrap } from '..'
 import { atom, computed, EXTENSIONS, notify, withActions } from '../core'
 import { connectLogger, log } from './connectLogger'
 import { getStackTrace } from './getStackTrace'
@@ -115,6 +115,73 @@ test('connectLogger match', () => {
   expect(logs.some((log) => String(log).includes('blocked'))).toBe(false)
 
   vi.restoreAllMocks()
+})
+
+test('connectLogger logs a computed initialization once on cold reads', () => {
+  const groupSpy = vi
+    .spyOn(console, 'groupCollapsed')
+    .mockImplementation(() => {})
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'groupEnd').mockImplementation(() => {})
+
+  connectLogger({ match: (name) => name === 'coldRead.doubled' })
+
+  const counter = atom(0, 'coldRead.counter')
+  const doubled = computed(() => counter() * 2, 'coldRead.doubled')
+
+  // remove the logger middleware to not interact with other tests
+  EXTENSIONS.pop()
+
+  try {
+    counter.set(24)
+    expect(peek(doubled)).toBe(48)
+    notify()
+
+    let doubledLogs = (groupSpy.mock.calls as unknown[][]).filter((call) =>
+      String(call[0]).includes('coldRead.doubled'),
+    )
+    expect(doubledLogs).toHaveLength(1)
+
+    expect(peek(doubled)).toBe(48)
+    notify()
+
+    doubledLogs = (groupSpy.mock.calls as unknown[][]).filter((call) =>
+      String(call[0]).includes('coldRead.doubled'),
+    )
+    expect(doubledLogs).toHaveLength(1)
+  } finally {
+    vi.restoreAllMocks()
+  }
+})
+
+test('connectLogger logs a computed initialization during subscription', () => {
+  const groupSpy = vi
+    .spyOn(console, 'groupCollapsed')
+    .mockImplementation(() => {})
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'groupEnd').mockImplementation(() => {})
+
+  connectLogger({ match: (name) => name === 'subscriptionInit.doubled' })
+
+  const counter = atom(0, 'subscriptionInit.counter')
+  const doubled = computed(() => counter() * 2, 'subscriptionInit.doubled')
+
+  // remove the logger middleware to not interact with other tests
+  EXTENSIONS.pop()
+
+  let unsubscribe: undefined | (() => void)
+  try {
+    unsubscribe = doubled.subscribe(() => {})
+    notify()
+
+    const doubledLogs = (groupSpy.mock.calls as unknown[][]).filter((call) =>
+      String(call[0]).includes('subscriptionInit.doubled'),
+    )
+    expect(doubledLogs).toHaveLength(1)
+  } finally {
+    unsubscribe?.()
+    vi.restoreAllMocks()
+  }
 })
 
 test('log.state logs only when data changes', () => {

--- a/packages/core/src/methods/connectLogger.ts
+++ b/packages/core/src/methods/connectLogger.ts
@@ -273,8 +273,6 @@ export let connectLogger = ({
       }
     }
 
-    let initKey = {}
-
     return target.extend(
       withMiddleware(
         () =>
@@ -294,12 +292,6 @@ export let connectLogger = ({
 
                 if (target.__reatom.reactive) {
                   if (Object.is(prevState, state)) return
-
-                  let inits = frame.root.inits
-                  if (!inits.has(initKey)) {
-                    inits.set(initKey, null)
-                    if (params.length === 0) return
-                  }
 
                   logStack(
                     state,


### PR DESCRIPTION
## Summary

- Log the first computed evaluation consistently, whether triggered by a cold read or by a subscription.
- Keep repeated reads of unchanged state from producing duplicate log entries.
- Add regression tests for both initialization paths.

## Context

[#647](https://github.com/reatom/reatom/issues/647) reports that reading an unconnected computed does not produce the expected logger entry.

The previous approach in [#1327](https://github.com/reatom/reatom/pull/1327) treated connected and disconnected computeds differently. This revision removes that distinction: computed initialization is now logged regardless of how the computation becomes active, while the existing unchanged-state check prevents duplicate logs.

## Testing

- `pnpm --filter @reatom/core test`

Fixes #647