### PR TITLE
fix(core): register rollback for writes to a lazy withComputed atom

### DIFF
--- a/packages/core/src/core/atom.ts
+++ b/packages/core/src/core/atom.ts
@@ -937,6 +937,8 @@ export function computedMiddleware(next: Fn, ...args: any[]) {
     (dirty || (dependent && !subscribed)) &&
     (!dependent || ((frame.pubs = [null]), _isPubsChanged(frame, pubs, 1)))
 
+  let writeCause: undefined | Frame
+
   // the second loop may come from push to emptyComputed
   while (push || invalid) {
     if (invalid) {
@@ -949,7 +951,7 @@ export function computedMiddleware(next: Fn, ...args: any[]) {
         frame.error = null
       } finally {
         frame.atom.__reatom.linking = false
-        frame.pubs[0] ??= frame.root.frame
+        frame.pubs[0] ??= writeCause ?? frame.root.frame
         // TODO
         // Object.freeze(frame.pubs)
 
@@ -968,7 +970,7 @@ export function computedMiddleware(next: Fn, ...args: any[]) {
       newState = frame.state =
         typeof update === 'function' ? update(newState) : update
       frame.error = null
-      frame.pubs[0] = STACK[STACK.length - 2]!
+      frame.pubs[0] = writeCause = STACK[STACK.length - 2]!
 
       invalid = emptyComputed && !Object.is(state, frame.state)
     }

--- a/packages/core/src/methods/transaction.test.ts
+++ b/packages/core/src/methods/transaction.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'test'
 
 import { _read, action, atom, notify } from '../core'
-import { withChangeHook } from '../extensions'
+import { withChangeHook, withComputed } from '../extensions'
 import { sleep } from '../utils'
 import { isCausedBy, wrap } from '.'
 import { withRollback, withTransaction } from './transaction'
@@ -290,4 +290,46 @@ test('a repeated rollback() must be a no-op, not an un-rollback', () => {
   // and a repeated rollback() would re-apply the optimistic state.
   increment.rollback()
   expect(counter()).toBe(0)
+})
+
+test('optimistic write to a not-yet-read withComputed atom rolls back', async () => {
+  const seed = atom(['server'], 'seed')
+  const list = atom<string[]>([], 'list').extend(
+    withRollback(),
+    withComputed((prev) => [
+      ...prev,
+      ...seed().filter((item) => !prev.includes(item)),
+    ]),
+  )
+
+  const save = action(async () => {
+    list.set((state) => ['optimistic', ...state])
+    await wrap(sleep())
+    throw new Error('test')
+  }, 'save').extend(withTransaction())
+
+  save()
+  expect(list()).toEqual(['optimistic', 'server'])
+
+  await wrap(sleep(10))
+  expect(list()).toEqual(['server'])
+})
+
+test('optimistic write to a zero-deps withComputed atom rolls back', async () => {
+  const list = atom<string[]>([], 'list').extend(
+    withRollback(),
+    withComputed((prev) => (prev.length ? prev : ['server'])),
+  )
+
+  const save = action(async () => {
+    list.set((state) => ['optimistic', ...state])
+    await wrap(sleep())
+    throw new Error('test')
+  }, 'save').extend(withTransaction())
+
+  save()
+  expect(list()).toEqual(['optimistic', 'server'])
+
+  await wrap(sleep(10))
+  expect(list()).toEqual(['server'])
 })

--- a/packages/core/src/methods/transaction.ts
+++ b/packages/core/src/methods/transaction.ts
@@ -409,7 +409,7 @@ export let reatomTransaction = ({
           withMiddleware(
             () =>
               function withRollback(next: Fn, ...params: any[]) {
-                let prevState = top().state
+                let prevState = params.length === 0 ? top().state : next()
                 let nextState = next(...params)
 
                 if (!Object.is(prevState, nextState)) {


### PR DESCRIPTION
`withRollback` silently registers no undo when the atom it guards is also `withComputed` and the write is the first touch of that atom in the current frame. The write lands on the value, the transaction fails, and the optimistic state stays — no error, no warning, and `onRollback` is never invoked at all.

```ts
const seed = atom(['server'], 'seed')
const list = atom<string[]>([], 'list').extend(
  withRollback(),
  withComputed((prev) => [...prev, ...seed().filter((item) => !prev.includes(item))]),
)

const save = action(async () => {
  list.set((state) => ['optimistic', ...state])
  await wrap(sleep())
  throw new Error('test')
}, 'save').extend(withTransaction())

save()
await wrap(sleep(10))
list() // ['optimistic', 'server'] — expected ['server']
```

This is the shape any optimistic list or counter takes: a value derived from server data that the UI also writes into ahead of the response. It reproduces with `.set` and with `reatomArray`'s own `push`/`unshift`, and with a computed that reads its previous state as well as one that ignores it.

## Root cause

Two cooperating causes, one per layer.

**`withRollback` captured `prevState = top().state` before calling `next()`.** On a never-read `withComputed` atom the frame still holds the raw init state; the computed only materializes inside `next()`, in `computedMiddleware`. So `beforeState` would have been a state that never observably existed.

**The write lands on a dirty frame, so `computedMiddleware` re-runs the computed after the push** (the `emptyComputed` loop), and that recompute's `finally` did `frame.pubs[0] ??= frame.root.frame` — replacing the write's cause, set by the push branch, with the root frame. `findRollbacks()` walks exactly that `pubs[0]` chain from the atom up to the transaction; it hit the root, found no queue, and returned nothing. Hence no undo is ever pushed, which is why a custom `onRollback` is never called rather than being called with wrong arguments.

This also explains the two things that look like workarounds. Reading the atom in the same frame before writing pre-materializes it, so the frame is no longer dirty, no post-push recompute happens, and the cause survives — the rollback works. And `withInit` does not help in either extension order, because the frame is dirty regardless of what the init state is.

## The fix

`withRollback` now reads through the same inner chain before writing:

```ts
let prevState = params.length === 0 ? top().state : next()
```

That yields the true pre-write state for `beforeState` and materializes the frame, so for dependent computeds the cause-erasing recompute no longer fires.

`computedMiddleware` records the cause of a push and reuses it when the push triggers a recompute:

```ts
frame.pubs[0] = writeCause = STACK[STACK.length - 2]!
// …
frame.pubs[0] ??= writeCause ?? frame.root.frame
```

Scoped to push-triggered recomputes only — dependency-triggered recomputes still fall back to the root frame, so a stale cause cannot leak into an unrelated transaction.

**Neither half alone is sufficient.** With only the read pass, a zero-deps computed still loses the undo, since it recomputes after every push regardless of the dirty flag — that case is pinned by the second test. With only the cause fix, `beforeState` is the raw never-materialized state, so the rollback "restores" `[]` and, with dependencies unchanged, the computed never re-merges — the atom ends at `[]` instead of `['server']`.

## Two things worth a reviewer's attention

**The read pass costs an extra chain traversal per write** on atoms carrying `withRollback`. For an atom whose read has side effects this means one additional read per write — `withObservable`'s `getState` is the case that comes to mind, since it runs on every read by contract. The blast radius is limited to atoms that opted into `withRollback`, but it is a behaviour change rather than a pure bug fix.

**`pubs[0]` is also what `isCausedBy` reads.** The change narrows when the root frame is substituted, so causality reported for push-triggered recomputes is now the write rather than the root. That looks like the more truthful answer, but it is the line in this diff most worth a second opinion.

## Tests

Two tests added to `packages/core/src/methods/transaction.test.ts`, covering a dependent computed and a zero-deps computed. Both fail on `v1001` before the fix and pass after.

- unit (`vitest run`, includes typecheck): 59 files, 429 passed, 2 expected-fail, 2 skipped, no type errors
- browser (`vitest.browser.config.ts`): 14 files, 114 passed, 1 skipped

No existing test changed behaviour.
