### PR TITLE
chore: add github copilot agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,46 @@
+# Reatom — GitHub Copilot instructions
+
+We prefer English for all communication and files.
+
+This repo already ships rich agent knowledge. Prefer reading it over guessing:
+
+- [`AGENTS.md`](../AGENTS.md) — skills, symlink layout, and what not to touch.
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — full contributor guide.
+- [`skills/`](../skills/) — canonical Reatom v1001 knowledge. VS Code does not
+  auto-load these, so open the relevant `SKILL.md` / `REFERENCE.md` yourself:
+  - `skills/reatom` — core API, models, actions, forms, routing, persistence.
+  - `skills/reatom-async` — `wrap`, `withAsync`/`withAsyncData`, abort, sampling, Suspense.
+  - `skills/reatom-jsx` — `@reatom/jsx` native DOM JSX.
+  - `skills/reatom-review` — v1001 review checklist; load it before reviewing changes.
+
+## Hard rules
+
+- Branch from `v1001` and open pull requests against `v1001` (not `main`).
+- Commit with Conventional Commits: `<type>(<scope>): <description>`, where
+  `<scope>` is the package directory name (e.g. `react`, `core`, `jsx`).
+  Description is imperative, lowercase, no trailing period. Example:
+  `fix(core): add check for atoms with equal ids`.
+- Bug fixes must add a test that reproduces the bug.
+- New features must be tested and documented.
+- Use `@ts-expect-error` for known false positives; `@ts-ignore` only for
+  errors you are unsure about and want to suppress temporarily.
+
+## Skills and symlinks
+
+Edit agent skills only in [`skills/`](../skills/). `.cursor/skills/` and
+`.agents/skills/` are directory symlinks to it. Several readmes are file
+symlinks to skill references (`summary.md`, `docs/src/content/docs/summary.md`,
+`packages/core/README.md`, `packages/jsx/README.md`). **Do not diff, merge, or
+sync symlink targets** — identical content at these paths is expected.
+
+## Build and test
+
+- Install once from the repo root (Node 24.2.0, `pnpm@10.32.1` recommended):
+  `pnpm install` (installs all packages, builds only `@reatom/core`).
+- Build the package you edit: `pnpm --filter <PACKAGE_NAME> run build`.
+- Test it: `pnpm --filter <PACKAGE_NAME> run test`.
+
+## After meaningful changes
+
+Sync the change with the relevant JSDoc and the docs handbook
+(`docs/src/content/docs/handbook`).

--- a/.github/instructions/reatom-src.instructions.md
+++ b/.github/instructions/reatom-src.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: 'packages/*/src/**'
+---
+
+When changing package source, do not forget to add tests and documentation
+(JSDoc plus `docs/src/content/docs/handbook`) for important changes.
+
+For Reatom v1001 API conventions, read the relevant skill under `skills/`
+(`skills/reatom`, `skills/reatom-async`, `skills/reatom-jsx`) before writing code.


### PR DESCRIPTION
## Motivation

The repo has rich agent knowledge (`skills/`, `AGENTS.md`, `.cursor/`), but nothing is wired for GitHub Copilot / VS Code: there is no `.github/copilot-instructions.md`, and VS Code does not auto-discover `skills/`. Contributors using Copilot work without the project's conventions.

## Changes

- `.github/copilot-instructions.md` — a thin pointer (no content duplication) to `AGENTS.md`, `CONTRIBUTING.md`, and the `skills/`, plus the hard rules: branch/PR against `v1001`, Conventional Commits with package scope, tests for fixes, tests + docs for features, and the symlink "do not diff/sync" warning.
- `.github/instructions/reatom-src.instructions.md` — `applyTo: packages/*/src/**`, mirroring the Cursor `tests-and-comments` rule (tests + JSDoc + `docs/handbook`).

Respects the repo's no-duplication philosophy — points to `skills/` instead of copying them.

## Notes

Docs/config only, no functional or runtime changes.