### PR TITLE
fix(core): a returning reader must not re-count a cache hit already delivered

### DIFF
--- a/packages/core/src/async/withAsync.ts
+++ b/packages/core/src/async/withAsync.ts
@@ -244,6 +244,8 @@ export let withAsync: {
       return call
     }, `${target.name}._onSettle`)
 
+    let delivered = new WeakSet<Promise<any>>()
+
     let pending = createAtom(
       {
         // computed needed to ensure that `pending` (and `ready`) connection will connect the target
@@ -253,7 +255,7 @@ export let withAsync: {
             ifChanged(target, () => {
               const targetFrame = _read(target)
               const cacheState = targetFrame && cacheVar.first(targetFrame)
-              if (!cacheState) state++
+              if (!cacheState && !delivered.has(targetFrame?.state)) state++
             })
           } else {
             const calls = getCalls(target as Action)
@@ -344,7 +346,10 @@ export let withAsync: {
       const isPromiseFresh =
         promiseToTrack !== undefined && !touched.has(promiseToTrack)
 
-      if (isCacheHit) touched.add(promise)
+      if (isCacheHit) {
+        touched.add(promise)
+        delivered.add(promise)
+      }
 
       if (cacheState?.payload) {
         pending.set((state) => state + 1)

--- a/packages/core/src/extensions/withCache.test.ts
+++ b/packages/core/src/extensions/withCache.test.ts
@@ -580,3 +580,42 @@ test('remount after an SSR-hydrated cache hit must render, not throw the cache A
     }),
   )
 })
+
+test('pending recovers when a returning reader is answered by the cache', async () => {
+  const name = 'withCache.returnHitPending'
+  const sort = atom<'new' | 'popular'>('new', `${name}.sort`)
+  const shown = atom(true, `${name}.shown`)
+
+  const query = computed(async () => {
+    const srt = sort()
+    await wrap(sleep(25))
+    return srt
+  }, `${name}.query`).extend(withAsyncData({ initState: '' }), withCache())
+
+  const comp = computed(
+    () => (shown() ? query.pending() > 0 : false),
+    `${name}.reloading`,
+  )
+
+  subscribe(comp)
+
+  // 'new' goes unread mid-flight and settles into the cache
+  await wrap(sleep(8))
+  shown.set(false)
+  await wrap(sleep(30))
+
+  // 'popular' the same
+  sort.set('popular')
+  shown.set(true)
+  await wrap(sleep(8))
+  shown.set(false)
+  await wrap(sleep(30))
+
+  // back to 'new', answered by the cache
+  sort.set('new')
+  shown.set(true)
+  await wrap(sleep(60))
+
+  expect(query.pending()).toBe(0)
+  expect(query.ready()).toBe(true)
+})


### PR DESCRIPTION
Third counting bug in `withAsync`'s `pending`, after #1316 (hydrated hit lost a `+1`, counter sat at `-1`) and its follow-ups. This one is the mirror image: a returning reader's cache hit **gains** a `+1` that nothing settles, and the counter latches **above** zero.

Reproduced from a real app — a profile page whose poll grid has three tabs sharing one sort. After walking a few (tab × sort) combinations the grid showed skeletons forever, over rows that were already loaded, and never recovered.

## Symptom

`pending` sticks at `1`. `ready()` is permanently `false`, every `reloading`/skeleton gate derived from it stays on, and later real fetches settle back onto the same `+1` floor rather than to zero.

## Repro conditions

All four are required — dropping any one balances the counter (each verified by removal):

1. the view reads `pending` but never `data` — a list renders rows from its own container atom and only reads `pending`/`reloading` for the skeletons;
2. the view stops **reading** the query while a fetch is in flight, and the abandoned body settles while unread, delivering into the cache. No unmounting is involved: a conditional read is enough, which is exactly what a tab switch does to the previous tab's atoms in a component's dependency set;
3. a second param is abandoned the same way (if either round settles under a live read, it balances);
4. the reader returns to the **first** param and the cache answers it — a HIT. With `length: 1` the second record evicts the first, the return is a MISS, and everything balances; returning to a never-fetched param balances too.

## Mechanism

A hit's result is delivered synchronously through its own `pending.set(+1)` → `onFulfill` → `onSettle` (`-1`) pair, which is net zero and correct on its own.

But those `pending.set` calls re-enter `pending`'s computed, and its `ifChanged(target, …)` reads the target again. That read goes through `_cacheImpl`'s non-dirty path, which first `_copy`s the frame — carrying `state`, none of the `var#*` frame variables — and then short-circuits on unchanged pubs, leaving the copy in place. The change tracker now sees a changed state on a frame **without** the `cacheVar` mark and counts it as a fresh in-flight run.

Nothing ever settles that `+1`: the delivery pair has already completed, and the promise is in `touched`, so no `.then` tracking remains.

## Fix

A `delivered` WeakSet beside `touched`. A hit's result promise is marked at delivery time, and the counter skips a frame whose state is such a promise.

The two sets guard two halves of the same invariant ("every `+1` has exactly one `-1`") and are not interchangeable:

- `touched` means *"tracking is already attached to this promise, don't attach another"* — it contains fresh promises too, added during the computation, before `pending` can observe them;
- `delivered` means *"this promise's accounting is already complete"* — hits only.

Substituting `touched` for `delivered` in the guard was measured: **7 tests fail**, including `withAsyncData atom concurrent` and `computed retry`, because the guard then swallows the legitimate `+1` of every fresh run.

### Alternative considered and rejected

Preserving `var#*` variables across `_copy`. It turns the gate green, but `cacheVar` is a per-computation channel between the cache and async middlewares; a copy that keeps the mark is later read as a *current* hit, which measured as a re-delivery loop (the suite hangs).

The marker has to live on something whose identity outlives the frame, and the state promise is that thing — the same reasoning that made `touched` a promise-keyed set in #1316.

## Note for maintainers

The fix is local and symmetric to what is already there, but it is the third accounting bug in the same place, so the shape underneath is worth a look independently of this PR.

`pending` *infers* "a run started" by observing the target's frame changes, rather than being told. The middleware knows the exact moment a run starts and could increment explicitly. The reason it does not is stated in the code: `pending` must be a computed over the target so that subscribing to `pending`/`ready` **connects** the target — the counting is entangled with the laziness contract. Disentangling them is a `withAsync` refactor and a maintainer's call, not something to slip into a bugfix.

## Verification

- `@reatom/core`: 59 files, 428 passed, 2 expected-fail, 2 skipped — unchanged from before the fix
- `@reatom/react`: 38 passed
- the new gate fails on `v1001` without the fix and passes with it
