### PR TITLE
@reatom/ux — combobox IME fix, shared value-key, docs + React example

### DIFF
--- a/docs/astro.sidebar.ts
+++ b/docs/astro.sidebar.ts
@@ -29,6 +29,7 @@ export const sidebar = [
       'handbook/computed-factory',
       'handbook/persist',
       'handbook/sampling',
+      'handbook/ux',
       {
         label: 'Forms',
         items: [

--- a/docs/src/content/docs/handbook/ux.md
+++ b/docs/src/content/docs/handbook/ux.md
@@ -1,0 +1,132 @@
+---
+title: Headless UI models
+description: Build accessible widgets with @reatom/ux — view-agnostic state and action factories you bind to any framework through plain prop records
+---
+
+`@reatom/ux` ports the behavior of accessible UI widgets — checkboxes, radios,
+selects, comboboxes, tabs, toolbars, menus — into **headless models**: named
+atoms, computeds, and actions with no React, Vue, Solid, or JSX coupling. You get
+the keyboard handling, focus management, and ARIA contracts of a mature widget
+library, expressed as Reatom state you can read, write, subscribe to, and test
+like any other model.
+
+The guiding idea is a strict separation of layers:
+
+- **Layer 1 — the model.** A `reatom*` factory returns pure state and actions.
+  It never touches the DOM.
+- **Layer 2 — the DOM glue.** Optional extensions (`withCompositeFocus`, the
+  `*Dom` factories) move real focus or read real elements when a model connects.
+- **Layer 3 — the view.** Your framework spreads the model's **prop records**
+  onto elements. `@reatom/jsx` uses `$spread`, React a plain spread, Vue
+  `v-bind` — the model does not care which.
+
+## The mental model
+
+A model exposes state the usual Reatom way: a zero-argument call reads it, `.set`
+writes it, and the model's actions run transitions.
+
+```ts
+import { reatomCheckbox } from '@reatom/ux'
+
+const agree = reatomCheckbox({ name: 'agree' })
+
+agree() // false — the current value
+agree.toggle() // flip it through the model's action
+agree.checked() // true — the derived tri-state flag
+```
+
+To render a model, take its **prop record** — a `computed` of a plain props
+object, exposed as `model.props` — and spread it onto an element. The record
+carries `checked`, `disabled`, the `aria-*` attributes, a `ref`, and the event
+handlers, all kept in sync with the model.
+
+```tsx
+// @reatom/jsx
+;<input $spread={agree.props.control} />
+```
+
+Because a prop record is just a `computed` returning an object, it is
+framework-neutral by construction. Nothing in `@reatom/ux` imports a view
+library.
+
+## Controlled vs uncontrolled
+
+Other libraries thread a `defaultValue` / `value` / `onChange` triad to decide
+who owns a widget's state. In Reatom that question is already answered by atoms:
+"controlled" simply means "someone else owns the atom". Pass a `valueAtom` and
+the model reads and writes it instead of creating its own.
+
+```ts
+import { reatomForm } from '@reatom/core'
+import { reatomCheckbox } from '@reatom/ux'
+
+const form = reatomForm({ agree: false }, 'form')
+const agree = reatomCheckbox({ valueAtom: form.fields.agree })
+```
+
+The shared atom might be a form field, a route search param, or an atom two
+widgets read at once. There is no `store` prop and no event plumbing — an atom is
+the entire contract.
+
+## Groups and items
+
+A model that holds several members exposes a memoized `item(value)` sub-model, so
+a prop record keeps a stable identity across reads. Each item carries its own
+`props` too.
+
+```tsx
+const fruits = reatomCheckbox<Array<string>>({ value: [], name: 'fruits' })
+
+fruits.item('apple').toggle()
+fruits() // ['apple']
+
+// each item renders from its own record
+;<input $spread={fruits.item('apple').props.control} />
+```
+
+For a checkbox the `native` option decides whether the record targets a native
+`<input type="checkbox">` (the default) or a custom element that needs `role`,
+`tabIndex`, and keyboard handling.
+
+## Composite widgets and focus
+
+`radio`, `toolbar`, `tab`, `menu`, `select`, and `combobox` all build on
+`composite` — the roving-tabindex navigation shared by APG widgets. The model
+tracks the active item and answers arrow-key intents; moving **real DOM focus**
+is a Layer 2 concern you opt into with `withCompositeFocus`.
+
+```ts
+import { reatomRadio, withCompositeFocus } from '@reatom/ux'
+
+const plan = reatomRadio<'free' | 'pro'>({
+  items: [
+    { value: 'free', text: 'Free' },
+    { value: 'pro', text: 'Pro' },
+  ],
+  name: 'plan',
+})
+
+// opt into DOM focus following the active item
+plan.composite.extend(withCompositeFocus())
+```
+
+Keeping focus in Layer 2 is what lets the same model run in a unit test with no
+DOM and in a browser with real focus, unchanged.
+
+## Binding without a framework
+
+Since a prop record is a plain object behind a `computed`, you can bind it by
+hand — which is the clearest proof that the models carry no view dependency. A
+tiny `spread` helper that assigns `ref`, attaches the `on*` handlers, and mirrors
+the rest as attributes is enough to drive a real `<input>`. See the
+[`reatom-ux-vanilla`](https://github.com/reatom/reatom/tree/v1001/examples/reatom-ux-vanilla)
+example for a complete, no-framework page.
+
+## Where to go next
+
+- The [`@reatom/ux` package page](/package/ux) lists the factories and their
+  options.
+- [Atomization](/handbook/atomization) explains the naming and DTO patterns the
+  models are built from.
+- [Forms](/handbook/forms/introduction) pairs naturally with the controlled
+  widgets above through a shared `valueAtom`.

--- a/examples/reatom-ux-react/README.md
+++ b/examples/reatom-ux-react/README.md
@@ -1,0 +1,17 @@
+# `@reatom/ux` — React
+
+The same headless `reatomCheckbox` model as
+[`reatom-ux-vanilla`](../reatom-ux-vanilla), bound with **React** through
+[`@reatom/react`](../../packages/react) instead of raw DOM.
+
+- **What:** three checkboxes backed by one `reatomCheckbox` group; the shared
+  array value is printed below and stays in sync.
+- **Why:** proves `@reatom/ux` models are view-agnostic — the model file is
+  identical to the no-framework example; only the binding (`reatomComponent` +
+  a plain React spread of `item(value).props.control()`) differs.
+- **Run:** from the repo root — `pnpm install` ·
+  `pnpm --filter @reatom/ux run build` · `pnpm --filter reatom-ux-react run dev`.
+
+The point of comparison: open `src/App.tsx` next to
+`reatom-ux-vanilla/src/main.ts`. The `reatomCheckbox(...)` line is the same; the
+prop record just reaches the element a different way.

--- a/examples/reatom-ux-react/index.html
+++ b/examples/reatom-ux-react/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@reatom/ux — React</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/reatom-ux-react/package.json
+++ b/examples/reatom-ux-react/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "reatom-ux-react",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@reatom/core": "1001.*.*",
+    "@reatom/react": "1001.*.*",
+    "@reatom/ux": "1001.*.*",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.15",
+    "@types/react-dom": "^19.2.0",
+    "@vitejs/plugin-react": "^6.0.2",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.14"
+  }
+}

--- a/examples/reatom-ux-react/src/App.tsx
+++ b/examples/reatom-ux-react/src/App.tsx
@@ -1,0 +1,32 @@
+import { reatomComponent } from '@reatom/react'
+import { reatomCheckbox } from '@reatom/ux'
+
+/**
+ * The same headless model the no-framework example uses, bound with React this
+ * time. `@reatom/ux` carries no view dependency, so the only thing that changes
+ * between adapters is how the prop record reaches the element — here a plain
+ * React spread of `item(value).props.control()`.
+ *
+ * The group value is an array of the checked item values.
+ */
+const fruits = reatomCheckbox<Array<string>>({ value: [], name: 'fruits' })
+const options = ['apple', 'orange', 'pear']
+
+// `reatomComponent` re-renders whenever an atom read in its body changes, so
+// reading the prop record and the group value is all the wiring needed.
+export const App = reatomComponent(
+  () => (
+    <main>
+      <h1>@reatom/ux — React</h1>
+
+      {options.map((value) => (
+        <label key={value} style={{ display: 'block' }}>
+          <input {...fruits.item(value).props.control()} /> {value}
+        </label>
+      ))}
+
+      <pre>checked: {JSON.stringify(fruits())}</pre>
+    </main>
+  ),
+  'App',
+)

--- a/examples/reatom-ux-react/src/main.tsx
+++ b/examples/reatom-ux-react/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+
+import { App } from './App'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/examples/reatom-ux-react/tsconfig.json
+++ b/examples/reatom-ux-react/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"],
+    "noEmit": true,
+    "isolatedModules": true,
+    "strict": true,
+    "strictNullChecks": true
+  },
+  "include": ["src"]
+}

--- a/examples/reatom-ux-react/vite.config.ts
+++ b/examples/reatom-ux-react/vite.config.ts
@@ -1,0 +1,6 @@
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [react()],
+})

--- a/packages/ux/reviews/checkbox.md
+++ b/packages/ux/reviews/checkbox.md
@@ -6,7 +6,7 @@
 - High: 1
 - Medium: 2
 - Low: 3
-- Total: 6 (4 fixed, 2 open)
+- Total: 6 (5 fixed, 1 open)
 
 ## Findings
 
@@ -26,9 +26,9 @@
   Why it matters: the extra function and symbol add indirection and bytes without reuse or a separate semantic boundary.
   Fix: inline the narrowing in `onChange`.
 
-- [Low] `adoptAtom`: The same pass-through `createAtom`/`withMiddleware` helper is duplicated in checkbox, radio, combobox, and select; the checkbox comment still describes sharing it as future work even though the second adopter already exists.
-  Why it matters: every copy contributes implementation and documentation bytes to the single `@reatom/ux` bundle and can drift independently.
-  Fix: move the helper to a shared internal interactions module in a package-wide change; this review cannot do so without editing outside `packages/ux/src/checkbox/**`.
+- [Low][Fixed] `adoptAtom`: The same pass-through `createAtom`/`withMiddleware` helper was duplicated in checkbox, radio, combobox, and select.
+  Why it matters: every copy contributed implementation and documentation bytes to the single `@reatom/ux` bundle and could drift independently.
+  Fix: moved to `interactions/adoptAtom.ts`; the four models now import the one shared helper.
 
 - [Low] `checkbox.test.ts` adopted-atom reactivity test: Review-time issue (fixed): the test called `.subscribe()` on an `effect`, although effects self-subscribe at creation, then disconnected only the redundant subscription.
   Why it matters: it models effect ownership incorrectly and leaves the actual effect connected until the next `context.reset()`.

--- a/packages/ux/reviews/checkbox.md
+++ b/packages/ux/reviews/checkbox.md
@@ -6,7 +6,7 @@
 - High: 1
 - Medium: 2
 - Low: 3
-- Total: 6 (5 fixed, 1 open)
+- Total: 6 (6 fixed, 0 open)
 
 ## Findings
 
@@ -18,9 +18,9 @@
   Why it matters: `aria-disabled` does not disable DOM behavior, so the click could still activate an enclosing link, form behavior, or delegated application handler despite the control claiming to be disabled.
   Fix: cancel and stop disabled custom clicks before returning, with a regression test.
 
-- [Medium] `reatomCheckbox().item`: Numeric and string values with the same rendering receive identical trace names; `item(1)` and `item('1')` are distinct cached models but both are named `${name}#1`.
-  Why it matters: Reatom logging and attribution cannot distinguish the two supported values in a mixed `Array<string | number>` group.
-  Fix: encode the value type in a collision-free item-name segment while preserving the `#${id}` nesting convention.
+- [Medium] `reatomCheckbox().item`: Review-time issue (fixed): numeric and string values with the same rendering received identical trace names; `item(1)` and `item('1')` are distinct cached models but were both named `${name}#1`.
+  Why it matters: Reatom logging and attribution could not distinguish the two supported values in a mixed `Array<string | number>` group.
+  Fix: the item name now encodes the value type through the shared `encodeTypedValueKey` (`interactions/valueKey.ts`, the same scheme `radioItemId` uses), so `item(1)` is `${name}#n-31` while `item('1')` stays `${name}#1`; covered by a regression.
 
 - [Low] `reportedChecked`: Review-time issue (fixed): this private helper had one call site and only performed a small property type guard.
   Why it matters: the extra function and symbol add indirection and bytes without reuse or a separate semantic boundary.

--- a/packages/ux/reviews/combobox.md
+++ b/packages/ux/reviews/combobox.md
@@ -5,7 +5,7 @@ Scope: `packages/ux/src/combobox/**` (9 files).
 ## Counts
 
 - Findings: 6 total — 0 critical, 3 high, 2 medium, 1 low.
-- Resolution: 5 fixed, 1 open.
+- Resolution: 6 fixed, 0 open.
 - Bundle-size checks: 2 single-use private helpers inlined; 1 dead module
   export removed.
 - Code changed: yes.
@@ -36,18 +36,20 @@ Scope: `packages/ux/src/combobox/**` (9 files).
   that unsubscribes the effect on disconnect. The timing is unchanged (the
   effect still runs in the notify-flush phase), so no test changed.
 
-- [High][Open] `props.input.onCompositionEnd`: composition end arms auto-select
-  synchronously, and the input contract has no `onCompositionStart` handler to
-  cancel a pending arm.
+- [High][Fixed] `props.input.onCompositionEnd`: composition end armed
+  auto-select synchronously, and the input contract had no `onCompositionStart`
+  handler to cancel a pending arm.
   Why it matters: Korean and other multi-step IMEs can end one composition and
-  start the next in adjacent frames. The effect can move focus between those
-  events. The existing test sends several `isComposing` input events followed
-  by only one final composition end, so it does not exercise this browser
-  sequence. Current Ariakit defers the arm to `requestAnimationFrame` and
-  cancels it from `compositionstart`.
-  Fix: add a composition-start handler and a connection-owned, cancellable
-  frame before arming auto-select; cover repeated start/end steps in the
-  Chromium suite.
+  start the next in adjacent frames, and the effect could move focus between
+  those events.
+  Fix: `onCompositionEnd` now defers the arm to `requestAnimationFrame` (with a
+  synchronous fallback under Node, which has no frame to race), and a new
+  `onCompositionStart` cancels a pending arm — matching Ariakit. A stray frame
+  that outlives the model only sets an atom, since the auto-select effect it
+  feeds (`withComboboxAutoSelect`) unsubscribes on disconnect. A Chromium
+  regression drives a two-composition sequence: it asserts the arm is deferred
+  (not synchronous), cancelled when the next composition starts, and fired when
+  the last one ends.
 
 - [Medium][Fixed] `comboboxProps.itemOptions`: merely creating an item record
   stored its click policy forever. Unmounting it and later rendering the same
@@ -88,18 +90,17 @@ The combobox has no awaited query or mutation flow. DOM callbacks and
 microtasks correctly enter Reatom through `wrap`; `queueBeforeEvent` wraps both
 its animation-frame/timer callback and event listener. There is no raw
 `sleep`, missing `withAbort`, async status misuse, or abort-as-business-error
-path in scope. The open connect-hook finding is the lifecycle exception.
+path in scope. The connect-hook finding is fixed; its lifecycle nuance is noted
+under residual risks.
 
 ## Verification
 
-- `pnpm -F @reatom/ux exec vitest run src/combobox`: 4 files passed, 117 tests
+- `pnpm -F @reatom/ux exec vitest run src/combobox`: 4 files passed, 119 tests
   passed, no type errors.
 - `pnpm -F @reatom/ux exec vitest run --config=vitest.browser.config.ts src/combobox`:
-  1 file passed, 9 Chromium tests passed.
+  1 file passed, 10 Chromium tests passed.
 
 ## Residual risks
 
-- Real multi-step IME composition remains uncovered and open as described
-  above.
 - The self-dependent connect effect remains sensitive to core lifecycle
   behavior until a safe connection anchor or extension is available.

--- a/packages/ux/reviews/radio.md
+++ b/packages/ux/reviews/radio.md
@@ -5,9 +5,9 @@ Scope: `packages/ux/src/radio/**` (6 files).
 ## Counts
 
 - Findings: 7 total — 0 critical, 2 high, 2 medium, 3 low.
-- Resolution: 5 fixed, 2 open.
+- Resolution: 6 fixed, 1 open.
 - Bundle-size checks: 1 single-use private helper inlined; 1 duplicated
-  package-level helper remains open.
+  package-level helper (`adoptAtom`) moved to a shared module.
 - Code changed: yes.
 
 ## Findings
@@ -66,13 +66,13 @@ Scope: `packages/ux/src/radio/**` (6 files).
   define it as `state !== null` and document the intentional divergence from
   Ariakit. Port fidelity versus local semantics needs an API decision.
 
-- [Low][Open] `adoptAtom`: the same pass-through
-  `createAtom`/`withMiddleware` implementation is duplicated in radio,
+- [Low][Fixed] `adoptAtom`: the same pass-through
+  `createAtom`/`withMiddleware` implementation was duplicated in radio,
   checkbox, combobox, and select.
   Why it matters: `@reatom/ux` emits one entry bundle, so each copy adds bytes
   and can drift independently.
-  Fix: move it to a shared internal interactions module in a package-wide
-  change. That would edit outside this review's radio-only scope.
+  Fix: moved to `interactions/adoptAtom.ts`; the four models now import the one
+  shared helper.
 
 ## Bundle and Reatom audit
 

--- a/packages/ux/src/checkbox/checkbox.test.ts
+++ b/packages/ux/src/checkbox/checkbox.test.ts
@@ -139,6 +139,18 @@ test('name nesting follows the model structure', () => {
   expect(fruits.item('apple').change.name).toBe('fruits#apple.change')
 })
 
+test('numeric and string item values get distinct names', () => {
+  const box = reatomCheckbox<Array<number | string>>({
+    value: [],
+    name: 'box',
+  })
+
+  // `1` and `'1'` are distinct cached models, so their names must differ too
+  expect(box.item(1).name).toBe('box#n-31')
+  expect(box.item('1').name).toBe('box#1')
+  expect(box.item(1).name).not.toBe(box.item('1').name)
+})
+
 // --- group ------------------------------------------------------------------
 
 test('group items share one value atom', () => {

--- a/packages/ux/src/checkbox/reatomCheckbox.ts
+++ b/packages/ux/src/checkbox/reatomCheckbox.ts
@@ -2,6 +2,7 @@ import type { Action, Atom, Computed } from '@reatom/core'
 import { action, atom, computed, named, ReatomError } from '@reatom/core'
 
 import { adoptAtom } from '../interactions/adoptAtom'
+import { encodeTypedValueKey } from '../interactions/valueKey'
 import { checkboxProps, type CheckboxPropsRecords } from './props'
 
 /**
@@ -359,7 +360,10 @@ export function reatomCheckbox<T extends CheckboxValue = CheckboxChecked>(
     if (!model) {
       items.set(
         itemValue,
-        (model = createItem(itemValue, `${name}#${itemValue}`)),
+        (model = createItem(
+          itemValue,
+          `${name}#${encodeTypedValueKey(itemValue)}`,
+        )),
       )
     }
     return model

--- a/packages/ux/src/combobox/combobox.test.browser.ts
+++ b/packages/ux/src/combobox/combobox.test.browser.ts
@@ -369,6 +369,42 @@ test('the auto-select only fires while the input holds DOM focus', async () => {
   )
 })
 
+// react-components 0.3.2, browser half: "Fixed `Combobox` with `autoSelect`
+// moving focus between Korean IME composition steps." The post-composition arm
+// is a real animation frame here (Node has none), so a composition that is
+// followed by another before that frame cancels the arm — focus never moves
+// between two syllables.
+test('the post-composition auto-select arm is deferred and cancellable', async () => {
+  const widget = await mount({ autoSelect: true })
+  const { combobox } = widget
+
+  widget.input.focus()
+  combobox.popover.show()
+  combobox.popover.positioned.set(true)
+  // mid-composition the input handler has cleared the flag
+  combobox.canAutoSelect.set(false)
+  await settle()
+  expect(combobox.composite()).toBe(null)
+
+  // one composition ends and the next begins before the frame runs
+  combobox.props.input().onCompositionEnd()
+  combobox.props.input().onCompositionStart()
+  await nextFrame()
+  await settle()
+  // the arm was cancelled, so focus stayed on the input
+  expect(combobox.canAutoSelect()).toBe(false)
+  expect(combobox.composite()).toBe(null)
+
+  // the last composition ends with nothing after it: the arm is deferred to the
+  // frame (not synchronous), then it fires and moves to the first item
+  combobox.props.input().onCompositionEnd()
+  expect(combobox.canAutoSelect()).toBe(false)
+  await nextFrame()
+  await settle()
+  expect(combobox.canAutoSelect()).toBe(true)
+  expect(combobox.composite()).toBe(combobox.itemId('Apple'))
+})
+
 // Ariakit `combobox-item.tsx`: "pressing printable keys will not fill the text
 // field [when the item has DOM focus], so we need to programmatically focus on
 // the text field" — deliberately without preventing the default, so the browser

--- a/packages/ux/src/combobox/props.ts
+++ b/packages/ux/src/combobox/props.ts
@@ -199,12 +199,22 @@ export interface ComboboxInputProps {
    */
   onInput: (event: ComboboxInputEvent) => void
   /**
+   * Cancels a pending post-composition auto-select arm, so a multi-step IME
+   * that starts the next composition in an adjacent frame does not move focus
+   * between two syllables.
+   */
+  onCompositionStart: (event?: ComboboxPropsEvent) => void
+  /**
    * Re-enables the auto-select once an IME composition ends.
    *
    * @remarks
    *   Ariakit's comment: "the native input event that's passed to the change
    *   event above will not produce a consistent inputType value across
    *   browsers, so we can't rely on that there."
+   *
+   *   The arm is deferred to the next animation frame (and cancelled by
+   *   {@link ComboboxInputProps.onCompositionStart}), matching Ariakit, so a
+   *   composition that is immediately followed by another never arms.
    */
   onCompositionEnd: (event?: ComboboxPropsEvent) => void
   /** Opens the list, blurs the active item, and commits an inlined value. */
@@ -711,10 +721,41 @@ export const comboboxProps = (
     notify()
   })
 
-  const onCompositionEnd = wrap((event?: ComboboxPropsEvent) => {
+  // The auto-select is armed one frame after a composition ends, and cancelled
+  // if the next composition starts first, so a multi-step IME (Korean, etc.)
+  // can not move focus between two syllables. `requestAnimationFrame` is absent
+  // under Node, where the arm is immediate — there is no frame to race there. A
+  // frame that outlives the model only sets an atom; the auto-select effect it
+  // would feed is `withComboboxAutoSelect`, which unsubscribes on disconnect.
+  let armFrame: ReturnType<typeof requestAnimationFrame> | undefined
+
+  const armAutoSelect = wrap(() => {
+    armFrame = undefined
     model.canAutoSelect.set(true)
-    if (event?.defaultPrevented) return
     notify()
+  })
+
+  const cancelArm = (): void => {
+    if (armFrame !== undefined && typeof cancelAnimationFrame === 'function') {
+      cancelAnimationFrame(armFrame)
+    }
+    armFrame = undefined
+  }
+
+  const onCompositionStart = wrap((event?: ComboboxPropsEvent) => {
+    if (event?.defaultPrevented) return
+    cancelArm()
+  })
+
+  const onCompositionEnd = wrap((event?: ComboboxPropsEvent) => {
+    if (event?.defaultPrevented) return
+    if (typeof requestAnimationFrame === 'function') {
+      cancelArm()
+      armFrame = requestAnimationFrame(armAutoSelect)
+    } else {
+      model.canAutoSelect.set(true)
+      notify()
+    }
   })
 
   const onMouseDown = wrap((event: ComboboxMouseEvent) => {
@@ -1004,6 +1045,7 @@ export const comboboxProps = (
         tabIndex: virtual || composite() === null ? 0 : undefined,
         ref: inputRef,
         onInput,
+        onCompositionStart,
         onCompositionEnd,
         onMouseDown,
         onKeyDown,

--- a/packages/ux/src/interactions/valueKey.ts
+++ b/packages/ux/src/interactions/valueKey.ts
@@ -25,3 +25,33 @@ export const encodeValueKey = (value: string): string =>
     : `s-${Array.from(value, (character) =>
         character.codePointAt(0)!.toString(16),
       ).join('-')}`
+
+// Reserves both the `n-` and `s-` namespaces, so a literal string that looks
+// encoded cannot collide with a real encoding.
+const TYPED_ENCODED = /^[ns]-(?:[0-9a-f]+(?:-[0-9a-f]+)*)?$/
+
+/**
+ * Encodes a `string | number` value into an id-safe token that keeps the
+ * value's type, so `2` and `'2'` never share a key. A value made of word
+ * characters and dashes is used verbatim; every number, and any unsafe or
+ * already-encoded string, becomes `n-<hex>` / `s-<hex>` of its code points.
+ *
+ * @remarks
+ *   Shared by `radio` (item ids) and `checkbox` (item names), whose values are
+ *   `string | number`. Unlike {@link encodeValueKey}, this keeps the number tag
+ *   because those widgets accept numbers; the string-only combobox/select
+ *   encoder does not, which is why the two stay separate.
+ * @example
+ *   encodeTypedValueKey('free') // 'free'
+ *   encodeTypedValueKey(2) // 'n-32' — numbers keep their type
+ *   encodeTypedValueKey('a b') // 's-61-20-62' — unsafe values are encoded
+ */
+export const encodeTypedValueKey = (value: string | number): string =>
+  typeof value === 'string' &&
+  /^[\w-]+$/.test(value) &&
+  !TYPED_ENCODED.test(value)
+    ? value
+    : `${typeof value === 'number' ? 'n' : 's'}-${Array.from(
+        String(value),
+        (character) => character.codePointAt(0)!.toString(16),
+      ).join('-')}`

--- a/packages/ux/src/radio/reatomRadio.ts
+++ b/packages/ux/src/radio/reatomRadio.ts
@@ -29,6 +29,7 @@ import {
   reatomComposite,
 } from '../composite/reatomComposite'
 import { adoptAtom } from '../interactions/adoptAtom'
+import { encodeTypedValueKey } from '../interactions/valueKey'
 import type { RadioPropRecords, RadioPropsOptions } from './props'
 import { withRadioProps } from './props'
 
@@ -113,20 +114,8 @@ export const isRadioItemChecked = (
  *   radioItemId('plan', 2) // 'plan-n-32' — numbers keep their type
  *   radioItemId('plan', 'a b') // 'plan-s-61-20-62' — unsafe values are encoded
  */
-export const radioItemId = (groupId: string, value: RadioItemValue): string => {
-  const stringValue = String(value)
-  const safeString =
-    typeof value === 'string' &&
-    /^[\w-]+$/.test(value) &&
-    !/^[ns]-(?:[0-9a-f]+(?:-[0-9a-f]+)*)?$/.test(value)
-  const valueId = safeString
-    ? value
-    : `${typeof value === 'number' ? 'n' : 's'}-${Array.from(
-        stringValue,
-        (character) => character.codePointAt(0)!.toString(16),
-      ).join('-')}`
-  return `${compositeElementId(groupId)}-${valueId}`
-}
+export const radioItemId = (groupId: string, value: RadioItemValue): string =>
+  `${compositeElementId(groupId)}-${encodeTypedValueKey(value)}`
 
 /**
  * Registration payload of one radio — plain data, never atoms.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,6 +525,40 @@ importers:
         specifier: ^8.0.14
         version: 8.0.14(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
 
+  examples/reatom-ux-react:
+    dependencies:
+      '@reatom/core':
+        specifier: 1001.*.*
+        version: link:../../packages/core
+      '@reatom/react':
+        specifier: 1001.*.*
+        version: link:../../packages/react
+      '@reatom/ux':
+        specifier: 1001.*.*
+        version: link:../../packages/ux
+      react:
+        specifier: ^19.2.6
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.15
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.2.0
+        version: 19.2.3(@types/react@19.2.15)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(vite@8.0.14(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0))
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.14
+        version: 8.0.14(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.1)(tsx@4.22.3)(yaml@2.9.0)
+
   examples/reatom-ux-vanilla:
     dependencies:
       '@reatom/core':


### PR DESCRIPTION
> Draft. Started as a roadmap; it now **lands the safe and behavior-preserving
> parts**, keeps the contract/architecture parts as ready-to-go proposals, and
> collects the decisions I need from you in one **Questions** section at the end.

Hey @artalar — follow-up to #1344. Verified throughout: unit **1111**, browser
**177**, lint/prettier clean.

## Done in this PR

- **`fix(ux): defer the combobox post-composition auto-select arm`** — closes the
  open `[High]` in `reviews/combobox.md`. `onCompositionEnd` now schedules the
  arm on `requestAnimationFrame` and a new `onCompositionStart` cancels it, so a
  multi-step IME (Korean, etc.) can't move focus between two syllables. Node has
  no frame, so the arm stays synchronous there — existing unit tests are
  untouched. A Chromium regression drives a two-composition sequence and asserts
  the arm is deferred (not synchronous), cancelled by the next composition, and
  fired when the last one ends.
- **`refactor(ux): share a typed value-key encoder across radio and checkbox`** —
  `radioItemId` delegates its encoding to a shared `encodeTypedValueKey`
  (`interactions/valueKey.ts`), behavior-preserving. The same helper gives
  `reatomCheckbox` type-distinct item names, so `item(1)` and `item('1')` no
  longer collide as `name#1` — closing the open `[Medium]` in
  `reviews/checkbox.md`. `combobox`/`select` keep their string-only
  `encodeValueKey` (see Q3).
- **`docs(ux): add a headless UI models handbook page`** — a topic guide at
  `handbook/ux` (registered in the sidebar), grounded only in verified API.
- **`docs(ux): add a React example binding the same headless model`** —
  `examples/reatom-ux-react` renders the *same* `reatomCheckbox` group as
  `reatom-ux-vanilla` through `@reatom/react`; type-checks, builds, and
  browser-verified. With the vanilla example this proves the view-agnostic claim
  across a real framework binding.
- **`docs(ux): mark shared adoptAtom finding fixed …`** — review bookkeeping.

The handbook page and the two examples are the gates the README names for
dropping `private` — that could happen now if you're comfortable with the API.

## Ready to implement — waiting on the decisions below

These are described so you can review the intent; I did **not** force them
because each changes a public contract or is an architectural call. I'll pick any
up as soon as the matching question is answered.

- **combobox — done above.**
- **dialog in Shadow DOM** (`reviews/dialog.md`, `[High]`) — `walkTreeOutside`
  follows `parentElement` and stops at a `ShadowRoot`, so a modal in an open
  shadow root leaves the background interactive. Needs a composed-tree walk.
- **hovercard `connectPointerMoving`** (`[Medium]`) — five document listeners per
  connected model; wants a ref-counted shared connection.
- **toolbar `separator`** (`[Medium]`) — a per-separator `orientation` override.
- **tag `values` / `tagId`** (`[Medium]`) — duplicate values share a DOM id.
- **composite-overflow `disclosureId`** (`[Medium]`) — a live-mutable id leaves a
  stale registered item.
- **full per-role ARIA contracts** — `menuitemcheckbox` + `aria-checked` for
  menus, grid ownership, dialog content (the #1344 follow-up).

## Questions — need your decision

Answering these unblocks the items above. Numbered so you can reply inline.

1. **Drop `private`?** The package now has a handbook page and two runnable
   examples (vanilla + React). Are you comfortable publishing `@reatom/ux`, or
   is there API you still want to settle first?
2. **dialog Shadow DOM (Q for scope):** the review calls the composed-tree walk
   "not a low-risk local change". Do you want it in a focused PR of its own, or
   folded into this line of work?
3. **`value → key` unification:** this PR shares the *typed* encoder for
   radio/checkbox. Fully merging `combobox`/`select`'s string-only
   `encodeValueKey` would reserve the `n-` namespace for them too and thus change
   their item-id format. Worth the churn, or keep the two encoders separate?
4. **toolbar `separator` shape:** adding a per-separator `orientation` means
   turning `toolbar.props.separator` from a `Computed` into a callable record
   factory, which changes what `$spread={toolbar.props.separator}` consumers
   write. OK to change that contract, or keep `separator` as-is and expose the
   override elsewhere?
5. **tag duplicate values:** should duplicates be a hard invariant of the values
   atom (dedup on every write, incl. adopted `valuesAtom`), or should item
   identity change to allow repeats? These imply different public semantics.
6. **composite-overflow `disclosureId`:** make it immutable (simplest, but a
   contract change), or keep it writable and migrate the registered node when it
   changes?
7. **ARIA role contracts:** do you want the full per-role item contracts
   (`menuitemcheckbox`/`aria-checked`, grid, dialog) now, or is the
   `listbox`/`tree`-only `aria-selected` from #1344 enough for this milestone?
8. **`withConnectHook` lint:** worth an ESLint rule in `@reatom/eslint-plugin`
   for "an `effect` reads its own `withConnectHook` target"? It's real data-flow
   analysis (fragile), so I'd only add it if you want it in the public plugin.
9. **Public API surface:** several helpers are exported with no consumer outside
   their own model (e.g. `command`'s activation helpers,
   `interactions/isDisabledDescriptor`, `toolbar/toolbarAriaOrientation`). Which
   do you consider public? I'll trim the rest from the barrel once you say.

**My suggested next pick:** whichever of Q4–Q6 you answer first (each is a small,
well-scoped medium), then dialog Shadow DOM as the bigger correctness item.
