### PR TITLE
test(core): failing test for sleep leaking its timer on abort

### DIFF
--- a/packages/core/src/sleep.abort.test.ts
+++ b/packages/core/src/sleep.abort.test.ts
@@ -1,0 +1,42 @@
+import { expect, test, vi } from 'test'
+
+import { atom } from './core'
+import { withConnectHook } from './extensions'
+import { wrap } from './methods'
+import { isAbort, noop, sleep } from './utils'
+
+test('sleep clears its timer when the awaiting frame is aborted', async () => {
+  vi.useFakeTimers()
+
+  try {
+    let caught: unknown
+
+    const target = atom(0, 'target').extend(
+      withConnectHook(async () => {
+        try {
+          while (true) {
+            await wrap(sleep(10 * 60 * 1000))
+          }
+        } catch (error) {
+          caught = error
+        }
+      }),
+    )
+
+    const unsubscribe = target.subscribe(noop)
+    await Promise.resolve()
+
+    expect(vi.getTimerCount()).toBe(1)
+
+    unsubscribe()
+    // the rejection reaches the catch a few microtasks later
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(isAbort(caught)).toBe(true)
+    expect(vi.getTimerCount()).toBe(0)
+  } finally {
+    vi.useRealTimers()
+  }
+})


### PR DESCRIPTION
Failing test, no fix — just the repro.

`wrap(sleep(ms))` is the documented way to pause inside an effect — `effect`'s own JSDoc calls it "Abortable sleep == debounce" and shows it inside a `while (true)` polling loop (`packages/core/src/methods/effect.ts:40`). The rejection half of that promise works: aborting the surrounding frame rejects it with an `AbortError`. The timer half does not — `clearTimeout` is never called, so the timer stays pending for the whole delay and keeps the Node event loop alive. `withCache` already unrefs its own cleanup timer in `planCleanup`, so the concern is not new to the codebase.

The test asserts both halves: the abort is delivered, and the timer is still armed afterwards — which is the leak.

The same shape in a connect hook:

```ts
withConnectHook(async () => {
  while (true) await wrap(sleep(10 * 60 * 1000))
})
```

Run: `pnpm --filter @reatom/core run test:unit`

```
× sleep clears its timer when the awaiting frame is aborted
AssertionError: expected 1 to be +0 // Object.is equality
```
