### PR TITLE
fix(react,preact): abort the previous init phase on deps change in reatomFactoryComponent

### DIFF
--- a/packages/preact/src/reatomComponent.ts
+++ b/packages/preact/src/reatomComponent.ts
@@ -1,10 +1,12 @@
 import {
+  _read,
+  abortVar,
   action,
   assert,
-  bind,
   type Frame,
   named,
   notify,
+  type ReatomAbortController,
   reatomAbstractRender,
   ReatomError,
   type Rec,
@@ -30,10 +32,10 @@ type ReatomComponentOptions =
       abortOnUnmount?: boolean
     }
 
-type ReatomFactoryComponentOptions =
+type ReatomFactoryComponentOptions<Props> =
   | string
   | {
-      deps?: Array<string>
+      deps?: Array<keyof Props>
       name?: string
     }
 
@@ -157,33 +159,50 @@ export let reatomFactoryComponent = <Props extends Rec = {}>(
     initProps: Props,
     options: { name: string },
   ) => (props: Props) => ComponentChildren,
-  options?: ReatomFactoryComponentOptions,
+  options?: ReatomFactoryComponentOptions<Props>,
 ): PreactRender<Props> => {
-  const deps = typeof options === 'object' ? (options.deps ?? []) : []
+  const deps = (
+    typeof options === 'object' ? (options.deps ?? []) : []
+  ) as Array<string>
   const name = typeof options === 'object' ? options.name : options
+
+  type Instance = {
+    controller: ReatomAbortController
+    render: (props: Props) => ComponentChildren
+  }
 
   const Component: PreactRender<Props> = reatomComponent(
     (props: Props): ComponentChildren => {
-      const { abort, render } = useMemo(
-        (): {
-          abort: () => void
-          render: (props: Props) => ComponentChildren
-        } => {
-          const initAction = action(init, `${Component.name}._init`).extend(
-            withAbort(),
-          )
+      const [, recreate] = useState(0)
 
-          return {
-            abort: bind(initAction.abort),
-            render: initAction(props, { name: Component.name }),
-          }
-        },
+      const initAction = useMemo(
+        () => action(init, `${Component.name}._init`).extend(withAbort()),
+        [],
+      )
+
+      const box = useMemo(
+        () => ({ instance: null as null | Instance }),
         deps.map((dep) => props[dep]),
       )
 
-      useEffect(() => abort, [])
+      if (!box.instance || box.instance.controller.signal.aborted) {
+        box.instance = {
+          render: initAction(props, { name: Component.name }),
+          controller: abortVar.require(_read(initAction)!),
+        }
+      }
 
-      return render(props)
+      const { instance } = box
+
+      useEffect(() => {
+        if (instance.controller.signal.aborted) {
+          recreate((s) => s + 1)
+          return
+        }
+        return () => instance.controller.abort('unmount')
+      }, [instance])
+
+      return instance.render(props)
     },
     { deps, name, abortOnUnmount: false },
   )

--- a/packages/preact/src/reatomFactoryComponent.test.tsx
+++ b/packages/preact/src/reatomFactoryComponent.test.tsx
@@ -346,5 +346,78 @@ describe('reatomFactoryComponent', () => {
         document.querySelector('[data-testid="output"]')?.textContent,
       ).toBe('state-for-item-2')
     }))
-})
 
+  test('deps change aborts the previous init phase', () =>
+    context.start(async () => {
+      const controllers = new Map<string, ReatomAbortController>()
+      const abortedLoops: Array<string> = []
+      const loopTicks: Record<string, number> = {}
+
+      const abortedBeforeInit: Record<string, boolean> = {}
+
+      const ItemComponent = reatomFactoryComponent(
+        (props: { itemId: string }) => {
+          abortedBeforeInit[props.itemId] =
+            controllers.get('item-1')?.signal.aborted ?? false
+          controllers.set(props.itemId, abortVar.get()!)
+
+          const { itemId } = props
+          loopTicks[itemId] = 0
+
+          effect(async () => {
+            try {
+              while (true) {
+                await wrap(sleep())
+                loopTicks[itemId]!++
+              }
+            } catch (error) {
+              if (isAbort(error)) abortedLoops.push(itemId)
+            }
+          })
+
+          return () => <div data-testid="output">{props.itemId}</div>
+        },
+        { deps: ['itemId'], name: 'ItemComponent' },
+      )
+
+      const currentItemId = atom('item-1', 'currentItemId')
+
+      const App = reatomComponent(
+        () => <ItemComponent itemId={currentItemId()} />,
+        'App',
+      )
+
+      render(
+        <reatomContext.Provider value={top()}>
+          <App />
+        </reatomContext.Provider>,
+        document.getElementById('root')!,
+      )
+
+      await wrap(tick())
+      await wrap(sleep())
+      expect(controllers.get('item-1')!.signal.aborted).toBe(false)
+      expect(loopTicks['item-1']!).toBeGreaterThan(0)
+
+      currentItemId.set('item-2')
+      await wrap(tick())
+      await wrap(sleep())
+
+      expect(controllers.get('item-1')!.signal.aborted).toBe(true)
+      expect(abortedBeforeInit['item-2']).toBe(true)
+      expect(abortedLoops).toEqual(['item-1'])
+      expect(controllers.get('item-2')!.signal.aborted).toBe(false)
+
+      const item1Ticks = loopTicks['item-1']!
+      await wrap(sleep())
+      await wrap(sleep())
+      expect(loopTicks['item-1']).toBe(item1Ticks)
+      expect(loopTicks['item-2']!).toBeGreaterThan(0)
+
+      render(null, document.getElementById('root')!)
+      await wrap(tick())
+      await wrap(sleep())
+      expect(controllers.get('item-2')!.signal.aborted).toBe(true)
+      expect(abortedLoops).toEqual(['item-1', 'item-2'])
+    }))
+})

--- a/packages/react/src/reatomComponent.ts
+++ b/packages/react/src/reatomComponent.ts
@@ -3,7 +3,6 @@ import {
   abortVar,
   action,
   assert,
-  bind,
   type Fn,
   type Frame,
   named,
@@ -168,35 +167,36 @@ export let reatomFactoryComponent = <Props extends Rec = {}>(
     initProps: Props,
     options: { name: string },
   ) => (props: Props) => React.ReactNode,
-  options?: string | { deps?: Array<string>; name?: string },
+  options?: string | { deps?: Array<keyof Props>; name?: string },
 ): ((props: Props) => React.ReactNode) => {
-  const deps = typeof options === 'object' ? (options.deps ?? []) : []
+  const deps = (
+    typeof options === 'object' ? (options.deps ?? []) : []
+  ) as Array<string>
   const name = typeof options === 'object' ? options.name : options
 
   type Instance = {
     controller: ReatomAbortController
-    abort: Fn
     render: (props: Props) => React.ReactNode
   }
 
   const Component: Fn = reatomComponent(
     (props: Props) => {
       const [, recreate] = React.useState(0)
+
+      const initAction = React.useMemo(
+        () => action(init, `${Component.name}._init`).extend(withAbort()),
+        [],
+      )
+
       const box = React.useMemo(
         () => ({ instance: null as null | Instance }),
         deps.map((dep) => props[dep]),
       )
 
       if (!box.instance || box.instance.controller.signal.aborted) {
-        const initAction = action(init, `${Component.name}._init`).extend(
-          withAbort(),
-        )
-        const render = initAction(props, { name: Component.name })
-
         box.instance = {
-          render,
+          render: initAction(props, { name: Component.name }),
           controller: abortVar.require(_read(initAction)!),
-          abort: bind(initAction.abort),
         }
       }
 
@@ -207,7 +207,7 @@ export let reatomFactoryComponent = <Props extends Rec = {}>(
           recreate((s) => s + 1)
           return
         }
-        return () => instance.abort()
+        return () => instance.controller.abort('unmount')
       }, [instance])
 
       return instance.render(props)

--- a/packages/react/src/reatomFactoryComponent.test.tsx
+++ b/packages/react/src/reatomFactoryComponent.test.tsx
@@ -360,4 +360,78 @@ describe('reatomFactoryComponent', () => {
         document.querySelector('[data-testid="output"]')?.textContent,
       ).toBe('state-for-item-2')
     }))
+
+  test('deps change aborts the previous init phase', () =>
+    context.start(async () => {
+      const controllers = new Map<string, ReatomAbortController>()
+      const abortedLoops: Array<string> = []
+      const loopTicks: Record<string, number> = {}
+
+      const abortedBeforeInit: Record<string, boolean> = {}
+
+      const ItemComponent = reatomFactoryComponent(
+        (props: { itemId: string }) => {
+          abortedBeforeInit[props.itemId] =
+            controllers.get('item-1')?.signal.aborted ?? false
+          controllers.set(props.itemId, abortVar.get()!)
+
+          const { itemId } = props
+          loopTicks[itemId] = 0
+
+          effect(async () => {
+            try {
+              while (true) {
+                await wrap(sleep())
+                loopTicks[itemId]!++
+              }
+            } catch (error) {
+              if (isAbort(error)) abortedLoops.push(itemId)
+            }
+          })
+
+          return () => <div data-testid="output">{props.itemId}</div>
+        },
+        { deps: ['itemId'], name: 'ItemComponent' },
+      )
+
+      const currentItemId = atom('item-1', 'currentItemId')
+
+      const App = reatomComponent(
+        () => <ItemComponent itemId={currentItemId()} />,
+        'App',
+      )
+
+      const root = ReactDOM.createRoot(document.getElementById('root')!)
+      root.render(
+        <reatomContext.Provider value={top()}>
+          <App />
+        </reatomContext.Provider>,
+      )
+
+      await wrap(tick())
+      await wrap(sleep())
+      expect(controllers.get('item-1')!.signal.aborted).toBe(false)
+      expect(loopTicks['item-1']!).toBeGreaterThan(0)
+
+      currentItemId.set('item-2')
+      await wrap(tick())
+      await wrap(sleep())
+
+      expect(controllers.get('item-1')!.signal.aborted).toBe(true)
+      expect(abortedBeforeInit['item-2']).toBe(true)
+      expect(abortedLoops).toEqual(['item-1'])
+      expect(controllers.get('item-2')!.signal.aborted).toBe(false)
+
+      const item1Ticks = loopTicks['item-1']!
+      await wrap(sleep())
+      await wrap(sleep())
+      expect(loopTicks['item-1']).toBe(item1Ticks)
+      expect(loopTicks['item-2']!).toBeGreaterThan(0)
+
+      root.unmount()
+      await wrap(tick())
+      await wrap(sleep())
+      expect(controllers.get('item-2')!.signal.aborted).toBe(true)
+      expect(abortedLoops).toEqual(['item-1', 'item-2'])
+    }))
 })


### PR DESCRIPTION
## What

Two changes to `reatomFactoryComponent` in both the `react` and `preact` adapters:

1. `deps` is now typed as `Array<keyof Props>` — an unknown prop key is a compile-time error.
2. A deps change now destroys the previous init phase **synchronously, before the new init body runs**.

## The problem

Each recreation of the init phase built a brand-new `_init` action with its own fresh `withAbort()` state, so calls never chained and "last-in-win" had nothing to win against:

- **react**: the previous phase was aborted only asynchronously, in the `useEffect` cleanup after the commit. Between the new init call (render) and the old cleanup (effect), two phases were alive simultaneously — two polling loops, two subscriptions to the same resource, etc. A render that React discarded before commit could also orphan a phase that nothing would ever abort.
- **preact**: the previous phase was **never aborted at all** on deps change. `useEffect(() => abort, [])` captured the `abort` of the first `initAction` only, so every deps change leaked the previous phase (effects and polling loops kept running until unmount, and only the first phase was aborted then).

## The fix

The `_init` action is hoisted into a stable `useMemo(..., [])` — one action per component instance, extended with the default `withAbort()` (last-in-win). Re-calling that same action on deps change is now itself the destruction of the previous phase: `withAbort` aborts the active controllers of the previous call before invoking the new init body, so the ordering guarantee is "release, then re-acquire". As a bonus, last-in-win also collects orphan phases created by renders React discarded before commit — the next call aborts them automatically.

## Two non-obvious constraints

The code deliberately keeps two things that may look like they could be simplified away:

1. **The unmount cleanup aborts `instance.controller` directly, not via `initAction.abort()`.** With the shared action, React runs the old effect's cleanup *after* the render that already created the next phase. At that point `initAction.abort()` would abort the *new* phase (the active-controllers list only holds the new controller), forcing a redundant re-init on every deps change. Each instance must abort exactly its own controller.

2. **The init call stays in the render body behind the mutable `box` guard, not inside the deps-keyed `useMemo` factory.** StrictMode dev double-invokes `useMemo` factories per compute. With last-in-win, the second invocation aborts the first one's controller while React keeps the *first* result — the kept instance is born aborted, the effect schedules a recreate, and the component loops forever ("Maximum update depth exceeded"). The box makes the second render pass idempotent: it sees the live instance and skips the call, so exactly one phase is created per recompute. (The `recreate` dance from #1324 is preserved unchanged for StrictMode remounts.)

## Tests

New test in both packages, `deps change aborts the previous init phase`: the init phase starts a polling loop via `effect`; on `itemId` change the test asserts the previous controller is already aborted **at the moment the new init body runs** (`abortedBeforeInit`), the old loop stops with an `AbortError` and never ticks again, the new phase keeps polling, and unmount aborts the last phase.

- react: 39/39, including both StrictMode tests from #1324
- preact: 32/32 browser + 17/17 unit
- `tsc` in both packages: no new errors; `deps: ['wrongKey']` fails to compile, valid keys pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
