### PR TITLE
fix(core): reset must unlink the pubs it drops

### DIFF
--- a/packages/core/src/core/atom.ts
+++ b/packages/core/src/core/atom.ts
@@ -611,7 +611,7 @@ function link(frame: Frame) {
 // but in the real data, it is in the best case quite often (pub.subs.pop()).
 // For example, as we run `link` before `unlink` during deps invalidation,
 // for deps duplication we want to find just added dep.
-function unlink(sub: AtomLike, oldPubs: Frame['pubs']) {
+export function _unlink(sub: AtomLike, oldPubs: Frame['pubs']) {
   // Start from the end to try to revet the link sequence with just "pop" complexity.
   // Do not unlink the zero pub, as it is just an actualization flag.
   for (let i = oldPubs.length - 1; i > 0; i--) {
@@ -628,7 +628,7 @@ function unlink(sub: AtomLike, oldPubs: Frame['pubs']) {
         if (pub.atom.__reatom.onConnect !== undefined) {
           _enqueue(pub.atom.__reatom.onConnect.abort, 'effect')
         }
-        unlink(pub.atom, pub.pubs)
+        _unlink(pub.atom, pub.pubs)
       }
     } else {
       // Search the suitable element (not effect) from the end to reduce the shift (`splice`) complexity.
@@ -650,7 +650,7 @@ function relink(frame: Frame, oldPubs: Frame['pubs']) {
   }
   if (changed) {
     link(frame)
-    unlink(frame.atom, oldPubs)
+    _unlink(frame.atom, oldPubs)
   }
 }
 
@@ -783,7 +783,7 @@ function subscribe(this: AtomLike, userCb?: Fn, errorCb?: Fn) {
       if (frame.atom.__reatom.onConnect !== undefined) {
         _enqueue(frame.atom.__reatom.onConnect.abort, 'effect')
       }
-      unlink(this, _getFrame(this, parentFrame.root)!.pubs)
+      _unlink(this, _getFrame(this, parentFrame.root)!.pubs)
     }
   }, parentFrame.root.frame)
 }

--- a/packages/core/src/methods/retry.test.ts
+++ b/packages/core/src/methods/retry.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from 'test'
 
 import { withAsync } from '../async'
-import { action, computed } from '../core'
+import { _read, action, atom, computed, isConnected } from '../core'
+import { withConnectHook } from '../extensions'
+import { sleep } from '../utils'
 import { retryComputed } from './retry'
 import { wrap } from './wrap'
 
@@ -48,4 +50,50 @@ test('retryComputed should recalculate dependent computeds', async () => {
   expect(valuesB.length).toBe(2) // This is the bug - computedB is not notified
   expect(newA).not.toBe(initialA) // Should be a new random value
   expect(newB).toBe(newA * 10) // computedB should have recalculated
+})
+
+test('retryComputed does not duplicate the target in its dependency subs', () => {
+  const source = atom(0, 'leak.source')
+  const derived = computed(() => source(), 'leak.derived')
+
+  const unsubscribe = derived.subscribe(() => {})
+
+  expect(_read(source)!.subs.length).toBe(1)
+
+  retryComputed(derived)
+  retryComputed(derived)
+  retryComputed(derived)
+
+  expect(_read(source)!.subs.length).toBe(1)
+
+  unsubscribe()
+})
+
+test('a retried computed still disconnects its dependencies when unsubscribed', async () => {
+  let connected = 0
+  let disconnected = 0
+
+  const source = atom(0, 'leak2.source').extend(
+    withConnectHook(() => {
+      connected++
+      return () => {
+        disconnected++
+      }
+    }),
+  )
+  const derived = computed(() => source(), 'leak2.derived')
+
+  const unsubscribe = derived.subscribe(() => {})
+  await wrap(sleep())
+  expect(connected).toBe(1)
+
+  retryComputed(derived)
+  retryComputed(derived)
+  await wrap(sleep())
+
+  unsubscribe()
+  await wrap(sleep())
+
+  expect(isConnected(source)).toBe(false)
+  expect(disconnected).toBe(connected)
 })

--- a/packages/core/src/methods/retry.ts
+++ b/packages/core/src/methods/retry.ts
@@ -1,5 +1,5 @@
 import type { Action, AtomLike } from '../core'
-import { _mark, _read, ReatomError } from '../core'
+import { _mark, _read, _unlink, ReatomError } from '../core'
 import { _copy } from '../core'
 
 /**
@@ -19,8 +19,10 @@ export const reset = <T extends AtomLike>(target: T) => {
 
   let targetFrame = _read(target)
   if (targetFrame) {
-    // FIXME: `splice` only new frame, do not brake immutability!
-    _copy(targetFrame).pubs.splice(1)
+    let frame = _copy(targetFrame)
+    _unlink(target, frame.pubs)
+    frame.pubs.length = 1
+
     if (targetFrame.subs.length > 0) {
       _mark(targetFrame)
     }


### PR DESCRIPTION
## The bug

`reset` drops the frame's own dependency list:

```ts
_copy(targetFrame).pubs.splice(1)
```

but the dependencies still name the target in their `subs`. On the next computation the actualization path hands `relink` the pubs snapshot — the list `reset` has already emptied — so `link` pushes the target into every fresh pub while `unlink` walks the empty old list and finds nothing to remove.

Each reset therefore leaves one more copy of the target in every dependency's `subs`.

The leftovers are not merely untidy. The last-subscriber bookkeeping in `unlink` — `onConnect.abort` plus the recursive unlink — only runs in the `subs.pop()` branch, when the array actually reaches zero. With N stale copies it never does, so the dependency stays "connected" forever and its connect hook is never aborted.

## How it shows up

`withAsync` hits this on a completely normal path: it calls `retryComputed(pending)` on every fresh run, and `_pending`'s only pub is the target itself. So an async computed that is re-run periodically (a poll, a revalidation loop) accumulates one `_pending` entry per run, and after the last real subscriber leaves it keeps running — the connect hook that started the loop never receives its abort.

Reproduced without any async machinery in the first test below: three `retryComputed` calls on a plain `computed` leave `subs.length === 4` where it should be `1`.

## The fix

Route the removal through the same `unlink` that `relink` uses:

```ts
let frame = _copy(targetFrame)
_unlink(target, frame.pubs)
frame.pubs.length = 1
```

`unlink` becomes `_unlink` (rename + export, four internal call sites updated). Nothing is reimplemented — the recursive unlink and the abort enqueue stay in one place. The `FIXME` on the old line goes away with it.

## Alternatives considered

**Only mark the frame dirty, leave `pubs` alone.** The most appealing option, but the truncation is load-bearing: for a subscribed computed, `invalid` also requires `_isPubsChanged`, and emptying the list is what makes it report a change. Dropping the truncation fails four existing tests (`computed retry`, `atom retry works without cacheParams`, `withAsyncData for computed retry`, `reset action resets dependencies and data`).

**Strip the `subs` entries in `reset` by hand, without the cascade.** Fixes the duplication but not the disconnect, and duplicates `unlink`'s bookkeeping next to it.

## Behaviour note

This makes `reset` genuinely drop the links, so a dependency held by nothing else now disconnects and reconnects around each retry — `retryComputed` touches the connect hooks of its dependency subtree. No existing test objects, and it follows from what `reset` means, but it is a real change for anyone holding a socket or a loop on a dependency's connect hook. It is why the second test asserts that connects and disconnects stay balanced rather than that exactly one disconnect happens.

## Tests

Two added to `packages/core/src/methods/retry.test.ts`. Both fail on `v1001` and pass with the fix:

- `retryComputed does not duplicate the target in its dependency subs` — `expected 4 to be 1`
- `a retried computed still disconnects its dependencies when unsubscribed` — `expected true to be false` on `isConnected`

Full `@reatom/core` suite: 429 passing, `tsc -b` and lint clean.
