### PR TITLE
test(core): reproduce phantom Error("undefined") on nullish rejection reason

### DIFF
--- a/packages/core/src/async/withAsync.test.ts
+++ b/packages/core/src/async/withAsync.test.ts
@@ -176,6 +176,23 @@ test('abort rejection settles without calling onReject', async () => {
   expect(onSettle).toHaveBeenCalledTimes(2)
 })
 
+test('rejection with a nullish reason does not produce a phantom Error("undefined")', async () => {
+  const fetchSmth = action(async () => 'real', 'phantomAbortError').extend(
+    withAsync(),
+  )
+  const unmock = mock(fetchSmth, () => Promise.reject(undefined))
+
+  try {
+    try {
+      await wrap(fetchSmth())
+    } catch {}
+
+    expect(fetchSmth.error()).toBeUndefined()
+  } finally {
+    unmock()
+  }
+})
+
 test('computed retry', async () => {
   const name = 'computedRetry'
   let shouldFail = true

--- a/packages/core/src/async/withAsyncData.test.ts
+++ b/packages/core/src/async/withAsyncData.test.ts
@@ -1,7 +1,7 @@
 import { expect, expectTypeOf, subscribe, test, vi } from 'test'
 
 import type { Atom } from '../core'
-import { action, atom, computed, context } from '../core'
+import { action, atom, computed, context, mock } from '../core'
 import { isInit, withCallHook, withConnectHook } from '../extensions'
 import { abortVar, effect, retryComputed, wrap } from '../methods'
 import { createMemStorage, reatomPersist } from '../persist'
@@ -429,6 +429,26 @@ test('status includes data property with initState', async () => {
   const statusFulfilled = fetch.status()
   expect(statusFulfilled.data).toBe(11)
   expect(statusFulfilled.isFulfilled).toBe(true)
+})
+
+test('rejection with a nullish reason stays consistent between error() and status().error', async () => {
+  const name = 'phantomAbortErrorData'
+  const fetchSmth = action(async () => 'real', `${name}.fetch`).extend(
+    withAsyncData({ status: true }),
+  )
+  const unmock = mock(fetchSmth, () => Promise.reject(undefined))
+
+  try {
+    try {
+      await wrap(fetchSmth())
+    } catch {}
+
+    expect(fetchSmth.error()).toBeUndefined()
+    expect(fetchSmth.status().error).toBeUndefined()
+    expect(fetchSmth.data()).toBeUndefined()
+  } finally {
+    unmock()
+  }
 })
 
 test('reset action resets dependencies and data', async () => {

--- a/packages/core/src/async/withAsyncStatus.test.ts
+++ b/packages/core/src/async/withAsyncStatus.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'test'
 
-import { action } from '../core'
+import { action, mock } from '../core'
 import { wrap } from '../methods'
 import { noop, sleep } from '../utils'
 import { withAsync } from './withAsync'
@@ -316,4 +316,23 @@ test('restore isFulfilled after abort', async () => {
     data: undefined as never,
     error: undefined,
   } satisfies AsyncStatusAbortedFulfill)
+})
+
+test('rejection with a nullish reason stays consistent between error() and status().error', async () => {
+  const fetchData = action(
+    async () => 'real',
+    'phantomAbortErrorStatus',
+  ).extend(withAsync({ status: true }))
+  const unmock = mock(fetchData, () => Promise.reject(undefined))
+
+  try {
+    try {
+      await wrap(fetchData())
+    } catch {}
+
+    expect(fetchData.error()).toBeUndefined()
+    expect(fetchData.status().error).toBeUndefined()
+  } finally {
+    unmock()
+  }
 })


### PR DESCRIPTION
## Summary

`withAsync`'s `onReject` and `withAsyncStatus`'s `getStatusError` disagree on how to treat a nullish (`undefined`/`null`) rejection reason. `onReject` only skips setting `error` when `isAbort(err)` is true; `getStatusError` additionally skips it when the rejection is `== null`. So a nullish rejection reason turns into a fabricated `Error("undefined")` via `error()`, while `status().error` correctly stays empty for the same rejection.

## Why this isn't just theoretical

`AbortController.abort()` with no argument is supposed to default `signal.reason` to a spec `AbortError`. Not every polyfill implements that default correctly — we've observed `signal.reason` staying `undefined` after a no-argument abort on React Native/Hermes. Anything awaiting a signal-driven promise (e.g. `fetch(url, { signal })`) on such a runtime can reject with `undefined` on an ordinary abort, and `withAsync` turns that into a phantom, misleading error.

## What this PR adds

Three failing regression tests (`withAsync.test.ts`, `withAsyncData.test.ts`, `withAsyncStatus.test.ts`) that mock a target to reject with `undefined` and assert `error()`/`status().error`/`data()` stay empty, consistent with how an abort is handled elsewhere. No fix is included — reporting the bug with tests first, open to discussing the right fix.

## Proposed fix (not applied here)

Align `onReject`'s guard with `getStatusError`'s, in `packages/core/src/async/withAsync.ts`:

```diff
-  if (!isAbort(err)) {
+  if (!isAbort(err) && err != null) {
     error.set((err = parseError(err)))
   }
```