### PR TITLE
test(core): stale unsubscribe after context.reset() breaks the new store

### DIFF
--- a/packages/core/src/core/atom.reset.test.ts
+++ b/packages/core/src/core/atom.reset.test.ts
@@ -1,9 +1,10 @@
 // use `vitest` instead of `test` only in this test file
-import { beforeEach, describe, expect, test } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 
+import { withConnectHook } from '../extensions'
 import { wrap } from '../methods'
 import { type AbortError, isAbort, sleep } from '../utils'
-import { atom, clearStack, context } from './atom'
+import { atom, clearStack, computed, context } from './atom'
 
 clearStack()
 
@@ -41,5 +42,65 @@ describe('context.reset', () => {
       const error = await wrappedPromise.catch((e) => e)
       expect(isAbort(error)).toBe(true)
       expect((error as AbortError).message).includes('context reset')
+    }))
+})
+
+describe('unsubscribe after context.reset', () => {
+  test('atom missing in the new store', () =>
+    root.run(() => {
+      const a = atom(0, 'a')
+      const staleUnsubscribe = a.subscribe()
+
+      context.reset()
+
+      expect(() => staleUnsubscribe()).not.toThrow()
+    }))
+
+  test('fresh subscription of the same atom stays linked', () =>
+    root.run(async () => {
+      const a = atom(0, 'a')
+      const doubled = computed(() => a() * 2, 'doubled')
+      const staleUnsubscribe = doubled.subscribe()
+
+      context.reset()
+
+      const fresh = vi.fn()
+      doubled.subscribe(fresh)
+      expect(fresh).toHaveBeenLastCalledWith(0)
+
+      staleUnsubscribe()
+
+      a.set(1)
+      await wrap(sleep())
+      expect(fresh).toHaveBeenLastCalledWith(2)
+
+      a.set(2)
+      await wrap(sleep())
+      expect(fresh).toHaveBeenLastCalledWith(4)
+    }))
+
+  test('fresh connection of the same atom is not aborted', () =>
+    root.run(async () => {
+      let connections = 0
+      const disconnect = vi.fn()
+      const a = atom(0, 'a').extend(
+        withConnectHook(() => {
+          const id = ++connections
+          return () => disconnect(id)
+        }),
+      )
+      const staleUnsubscribe = a.subscribe()
+      await wrap(sleep())
+      expect(connections).toBe(1)
+
+      context.reset()
+
+      a.subscribe()
+      await wrap(sleep())
+      expect(connections).toBe(2)
+
+      staleUnsubscribe()
+      await wrap(sleep())
+      expect(disconnect).not.toBeCalledWith(2)
     }))
 })


### PR DESCRIPTION
## Problem

`context.reset()` swaps the root store in place (`rootFrame.root = rootFrame.state = context.start().state`). An unsubscribe function returned by `atom.subscribe()` **before** the reset resolves its frame through the mutable `parentFrame.root`:

```ts
// packages/core/src/core/atom.ts, subscribe()
unlink(this, _getFrame(this, parentFrame.root)!.pubs)
```

Calling it **after** the reset goes one of two ways:

1. The atom has not been read in the new store yet → `_getFrame` is `undefined` → `TypeError: Cannot read properties of undefined (reading 'pubs')`.
2. The atom already has a fresh subscriber in the new store → `unlink` detaches the fresh frame's deps and `_enqueue(onConnect.abort)` aborts the fresh connection, so the new subscription silently stops reacting. This one is worse because nothing throws.

### How apps hit it

The JSDoc on `reset()` suggests "user logout". In a React app that means: the logout handler calls `context.reset()`, then React unmounts the old tree, and every `useSyncExternalStore` cleanup (`@reatom/react` `useAtom`) calls a stale unsubscribe. Any component that remounts after logout (a header, the router) either crashes the unmount or loses reactivity.

`wrap` already detects a reset with `root !== frame.root` (a061960, "wrap abort on reset"); the unsubscribe closure predates `reset` and never got the same guard.

## This PR

Tests only, per the project's preference — three failing cases in `atom.reset.test.ts`:

- unsubscribe after reset, atom missing in the new store → must not throw
- fresh subscription of the same atom stays linked (a computed keeps recomputing)
- fresh `withConnectHook` connection is not aborted by the stale unsubscribe

On `v1001` (b39d4e81):

```
× atom missing in the new store
  TypeError: Cannot read properties of undefined (reading 'pubs')
× fresh subscription of the same atom stays linked
  expected last "vi.fn()" call to have been called with [ 2 ]
× fresh connection of the same atom is not aborted
  expected "vi.fn()" to not be called with arguments: [ 2 ]
```

For reference, a minimal fix that makes them pass (verified locally against the full `pnpm test` run, incl. browser suites): capture `parentFrame.root.frame` at subscribe time, and in the unsubscribe closure return early after the `splice` when `frame.root !== rootFrame.root`, otherwise resolve the frame for `unlink` via `frame.root`. Same idiom as `wrap`. Happy to push it as a follow-up commit if you prefer it in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
